### PR TITLE
fix: add subdomain substitution for HomeBox

### DIFF
--- a/kubernetes/clusters/na/homebox.yaml
+++ b/kubernetes/clusters/na/homebox.yaml
@@ -22,6 +22,8 @@ spec:
     secretRef:
       name: sops-age
   postBuild:
+    substitute:
+      subdomain: homebox
     substituteFrom:
       - kind: ConfigMap
         name: cluster-settings


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Implemented build-time subdomain substitution for the Homebox environment to streamline configuration and ensure consistent deployments.
  - Reduces manual edits and lowers the risk of configuration drift, improving reliability during rollouts.
  - No functional or user-facing changes expected; behavior remains the same.
  - Enhances maintainability for future updates and environment-specific configurations without impacting runtime performance or availability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->