### PR TITLE
chore(pihole): dns changeover from manual to webapp base

### DIFF
--- a/kubernetes/apps/pihole/service.yaml
+++ b/kubernetes/apps/pihole/service.yaml
@@ -14,19 +14,19 @@ spec:
       port: 80
     - name: https
       port: 443
----
-apiVersion: v1
-kind: Service
-metadata:
-  name: pihole-dns
-  labels:
-    app: pihole
-spec:
-  type: LoadBalancer
-  selector:
-    app: pihole
-  externalTrafficPolicy: Local
-  ports:
-    - name: dns
-      port: 53
-      protocol: UDP
+# ---
+# apiVersion: v1
+# kind: Service
+# metadata:
+#   name: pihole-dns
+#   labels:
+#     app: pihole
+# spec:
+#   type: LoadBalancer
+#   selector:
+#     app: pihole
+#   externalTrafficPolicy: Local
+#   ports:
+#     - name: dns
+#       port: 53
+#       protocol: UDP

--- a/kubernetes/apps/pihole2/kustomization.yaml
+++ b/kubernetes/apps/pihole2/kustomization.yaml
@@ -5,6 +5,7 @@ resources:
 - ../webapp/base
 - secret.yaml
 - configMap.yaml
+- loadbalancer.yaml
 
 components:
 - ../webapp/components/ingress
@@ -40,6 +41,14 @@ patches:
   target: 
     kind: Deployment
     name: deploy
+- path: update-http-ports.yaml
+  target:
+    kind: Deployment
+    name: deploy
+- path: update-service-ports.yaml
+  target:
+    kind: Service
+    name: svc
 
 configMapGenerator:
   - name: env

--- a/kubernetes/apps/pihole2/loadbalancer.yaml
+++ b/kubernetes/apps/pihole2/loadbalancer.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: dns
+  labels:
+    app: pihole
+spec:
+  type: LoadBalancer
+  selector:
+    app: pihole
+  externalTrafficPolicy: Local
+  ports:
+    - name: dns
+      port: 53
+      protocol: UDP

--- a/kubernetes/apps/pihole2/loadbalancer.yaml
+++ b/kubernetes/apps/pihole2/loadbalancer.yaml
@@ -10,6 +10,9 @@ spec:
     app: pihole
   externalTrafficPolicy: Local
   ports:
-    - name: dns
+    - name: dns-udp
       port: 53
       protocol: UDP
+    - name: dns-tcp
+      port: 53
+      protocol: TCP

--- a/kubernetes/apps/pihole2/update-http-ports.yaml
+++ b/kubernetes/apps/pihole2/update-http-ports.yaml
@@ -1,0 +1,9 @@
+- op: replace
+  path: /spec/template/spec/containers/0/ports/0/containerPort
+  value: 80
+- op: add
+  path: /spec/template/spec/containers/0/ports/-
+  value:
+    containerPort: 443
+    name: https
+    protocol: TCP

--- a/kubernetes/apps/pihole2/update-service-ports.yaml
+++ b/kubernetes/apps/pihole2/update-service-ports.yaml
@@ -1,0 +1,9 @@
+- op: replace
+  path: /spec/ports/0/port
+  value: 80
+- op: add
+  path: /spec/ports/-
+  value:
+    port: 443
+    protocol: TCP
+    name: https

--- a/kubernetes/clusters/na/pihole2.yaml
+++ b/kubernetes/clusters/na/pihole2.yaml
@@ -7,6 +7,7 @@ metadata:
 spec:
   dependsOn:
     - name: nginx
+    - name: pihole
   interval: 1h
   retryInterval: 1m
   timeout: 5m


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Exposes DNS externally via a LoadBalancer (UDP and TCP 53) for pihole2.
  - Adds HTTPS (443) support alongside HTTP for pihole2.

- Changes
  - Removes the legacy secondary DNS Service for pihole; primary Service remains internal.

- Chores
  - Adjusts rollout order so pihole2 waits for required components before applying.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->