### PR TITLE
feat(orion): wire Gateway API, cert-manager, and Cilium ingress contr…

### DIFF
--- a/.taskfiles/LocalTest/Tasks.yml
+++ b/.taskfiles/LocalTest/Tasks.yml
@@ -73,7 +73,7 @@ tasks:
     cmds:
       - |
         flux push artifact oci://localhost:5001/home-lab-ops:latest \
-          --path ./kubernetes/ \
+          --path ./ \
           --source="$(git remote get-url origin)" \
           --revision="$(git rev-parse --short HEAD)"
 
@@ -92,7 +92,8 @@ tasks:
       # 1. Point Flux at the local OCI registry
       - |
         flux create source oci home-lab-ops \
-          --url=oci://localhost:5001/home-lab-ops:latest \
+          --url=oci://kind-registry:5000/home-lab-ops \
+          --tag=latest \
           --insecure \
           --interval=1m
       # 2. Apply cluster-settings ConfigMap so substituteFrom can resolve
@@ -112,7 +113,15 @@ tasks:
           echo "Applying $f"
           kubectl apply -f "$f"
         done
-      # 4. Watch until all Kustomizations are Ready
+      # 4. Patch every Kustomization's sourceRef to use the local OCIRepository.
+      #    The cluster YAMLs reference kind: GitRepository/flux-system (real cluster
+      #    bootstrap), but in kind we use an OCIRepository instead.
+      - |
+        kubectl get kustomization -n flux-system -o name | \
+          xargs -I{} kubectl patch {} -n flux-system \
+            --type=merge \
+            -p '{"spec":{"sourceRef":{"kind":"OCIRepository","name":"home-lab-ops"}}}'
+      # 5. Watch until all Kustomizations are Ready
       - flux get kustomizations --watch
 
   kind-down:

--- a/clusters/kind-config.yaml
+++ b/clusters/kind-config.yaml
@@ -10,5 +10,5 @@ containerdConfigPatches:
 - |-
   [plugins."io.containerd.grpc.v1.cri".registry]
     config_path = ""
-  [plugins."io.containerd.grpc.v1.cri".registry.mirrors."localhost:5001"]
-    endpoint = ["http://localhost:5001"]
+  [plugins."io.containerd.grpc.v1.cri".registry.mirrors."kind-registry:5000"]
+    endpoint = ["http://kind-registry:5000"]

--- a/kubernetes/clusters/orion/cert-manager.yaml
+++ b/kubernetes/clusters/orion/cert-manager.yaml
@@ -5,8 +5,6 @@ metadata:
   name: cert-manager
   namespace: flux-system
 spec:
-  dependsOn:
-    - name: cluster-settings
   interval: 1h
   retryInterval: 1m
   timeout: 5m
@@ -29,7 +27,6 @@ metadata:
 spec:
   dependsOn:
     - name: cert-manager
-    - name: cluster-settings
   interval: 10m
   retryInterval: 30s
   timeout: 1m30s

--- a/kubernetes/clusters/orion/cert-manager.yaml
+++ b/kubernetes/clusters/orion/cert-manager.yaml
@@ -1,0 +1,49 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: cert-manager
+  namespace: flux-system
+spec:
+  dependsOn:
+    - name: cluster-settings
+  interval: 1h
+  retryInterval: 1m
+  timeout: 5m
+  prune: true
+  wait: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+  path: ./kubernetes/infrastructure/cert-manager
+  decryption:
+    provider: sops
+    secretRef:
+      name: sops-age
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: cert-manager-issuers
+  namespace: flux-system
+spec:
+  dependsOn:
+    - name: cert-manager
+    - name: cluster-settings
+  interval: 10m
+  retryInterval: 30s
+  timeout: 1m30s
+  prune: true
+  wait: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+  path: ./kubernetes/infrastructure/cert-manager/issuers
+  decryption:
+    provider: sops
+    secretRef:
+      name: sops-age
+  postBuild:
+    substituteFrom:
+      - kind: ConfigMap
+        name: cluster-settings

--- a/kubernetes/clusters/orion/cluster-settings.yaml
+++ b/kubernetes/clusters/orion/cluster-settings.yaml
@@ -5,4 +5,5 @@ metadata:
   namespace: flux-system
 data:
   domain: orion.norseamerican.com
-  externalIp: 192.168.2.66
+  externalIp: 10.50.0.230
+  certCloudflareEmail: permalost.commercial+cloudflare@gmail.com

--- a/kubernetes/clusters/orion/gateway.yaml
+++ b/kubernetes/clusters/orion/gateway.yaml
@@ -1,0 +1,22 @@
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: gateway
+  namespace: flux-system
+spec:
+  dependsOn:
+    - name: cilium
+    - name: cert-manager-issuers
+  interval: 10m
+  retryInterval: 30s
+  timeout: 5m
+  prune: true
+  wait: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+  path: ./kubernetes/infrastructure/gateway
+  postBuild:
+    substituteFrom:
+      - kind: ConfigMap
+        name: cluster-settings

--- a/kubernetes/infrastructure/cert-manager/release.yaml
+++ b/kubernetes/infrastructure/cert-manager/release.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
   name: cert-manager

--- a/kubernetes/infrastructure/cert-manager/repository.yaml
+++ b/kubernetes/infrastructure/cert-manager/repository.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: source.toolkit.fluxcd.io/v1beta2
+apiVersion: source.toolkit.fluxcd.io/v1
 kind: HelmRepository
 metadata:
   name: cert-manager

--- a/kubernetes/infrastructure/cilium/README.md
+++ b/kubernetes/infrastructure/cilium/README.md
@@ -1,29 +1,122 @@
 # cilium
 
-CNI for both clusters, providing pod networking, L2 load balancer announcements (replacing MetalLB on orion), Gateway API, Hubble observability, and network policy enforcement.
+CNI for the orion cluster, providing pod networking, kube-proxy replacement, L2 load balancer announcements, Gateway API, Hubble observability, and network policy enforcement.
+
+## Bootstrap (before Flux)
+
+Talos sets `cni.name: none` so the cluster starts with no CNI. Pods (including Flux itself) cannot schedule until Cilium is running. This creates a chicken-and-egg problem: Flux can't install Cilium if Cilium isn't already there.
+
+**Solution:** install Cilium manually into `kube-system` once before bootstrapping Flux. This is the only manual Helm operation in the cluster lifecycle.
+
+```bash
+helm repo add cilium https://helm.cilium.io/
+helm repo update
+
+helm install cilium cilium/cilium \
+  --namespace kube-system \
+  --version 1.18.4 \
+  --set ipam.mode=kubernetes \
+  --set kubeProxyReplacement=true \
+  --set k8sServiceHost=localhost \
+  --set k8sServicePort=7445 \
+  --set cgroup.autoMount.enabled=false \
+  --set cgroup.hostRoot=/sys/fs/cgroup \
+  --set gatewayAPI.enabled=true \
+  --set gatewayAPI.enableAlpn=true \
+  --set gatewayAPI.enableAppProtocol=true \
+  --set hubble.enabled=true \
+  --set hubble.relay.enabled=true \
+  --set hubble.ui.enabled=true \
+  --set securityContext.capabilities.ciliumAgent="{CHOWN,KILL,NET_ADMIN,NET_RAW,IPC_LOCK,SYS_ADMIN,SYS_RESOURCE,DAC_OVERRIDE,FOWNER,SETGID,SETUID}" \
+  --set securityContext.capabilities.cleanCiliumState="{NET_ADMIN,SYS_ADMIN,SYS_RESOURCE}"
+```
+
+Wait for Cilium to report Ready before proceeding to Flux bootstrap:
+
+```bash
+kubectl -n kube-system rollout status daemonset/cilium
+```
+
+## Flux-managed install (cilium namespace)
+
+Once Flux is bootstrapped, it takes over Cilium management and installs it into the `cilium` namespace (see `release.yaml`). This includes additional features not needed for bare CNI: L2 announcements, ExternalIPs, the Cilium ingress controller, and TLS secret management.
+
+The `kube-system` bootstrap install must be removed before the Flux-managed install can become healthy. Both cannot run simultaneously — they share eBPF kernel maps and `cilium-envoy` hostPorts.
+
+### Migrating from kube-system to cilium namespace
+
+Run these steps during a maintenance window. There will be a brief CNI gap (seconds to ~1 minute) between removing the old install and the new DaemonSet becoming Ready.
+
+```bash
+# 1. Prevent Flux from fighting with the migration mid-flight
+flux suspend kustomization cilium -n flux-system
+
+# 2. Remove the bootstrap install
+helm uninstall cilium -n kube-system
+
+# 3. Wait for kube-system cilium pods to terminate
+kubectl -n kube-system get pods -l k8s-app=cilium -w
+
+# 4. Hand control back to Flux — it will install into the cilium namespace
+flux resume kustomization cilium -n flux-system
+
+# 5. Monitor
+kubectl get pods -n cilium -w
+flux get helmrelease cilium -n cilium -w
+```
+
+If the HelmRelease had previously exhausted its retry budget (3 retries), force a fresh reconcile:
+
+```bash
+flux reconcile helmrelease cilium -n cilium --reset
+```
 
 ## Configuration
 
-- **Chart:** `cilium/cilium` (>=1.16.0)
-- **Namespace:** `cilium` (HelmRelease targets the `cilium` namespace; Cilium then manages pod networking cluster-wide including `kube-system`)
-- **Values source:** ConfigMap (`values.yaml` via kustomize `configMapGenerator`)
+- **Chart:** `cilium/cilium` (`>=1.16.0`)
+- **Namespace:** `cilium` (Flux-managed); initial bootstrap targets `kube-system`
+- **Values source:** ConfigMap generated from `values.yaml` via kustomize `configMapGenerator`
 
 Key non-default choices:
-- `kubeProxyReplacement: true` — Talos has no kube-proxy; Cilium must replace it entirely
-- `k8sServiceHost` / `k8sServicePort` — explicitly set for Talos (no in-cluster DNS at bootstrap time)
-- L2 announcements enabled — Cilium serves the LoadBalancer IP pool directly (see `policies/ipPool.yaml` for the pool range) without MetalLB on orion
-- `SYS_MODULE` capability removed — required for Talos which does not allow kernel module loading from pods
+
+| Setting | Value | Reason |
+|---|---|---|
+| `kubeProxyReplacement` | `true` | Talos has no kube-proxy; Cilium must replace it entirely |
+| `k8sServiceHost` / `k8sServicePort` | `localhost:7445` | Talos local API proxy; no in-cluster DNS at bootstrap time |
+| `cgroup.autoMount.enabled` | `false` | Talos mounts cgroups itself; Cilium must not remount |
+| `cgroup.hostRoot` | `/sys/fs/cgroup` | Talos cgroup v2 mount path |
+| `l2announcements.enabled` | `true` | Replaces MetalLB for LoadBalancer IP announcement on orion |
+| `tls.secretsNamespace.name` | `cilium` | TLS secrets for Gateway API placed in the Cilium namespace |
+| `operator.replicas` | `1` | Sufficient for a five-node homelab |
+| `SYS_MODULE` omitted | — | Talos does not allow kernel module loading from pods |
 
 ## Dependencies
 
-Must be the first component applied. No other pods will schedule until Cilium is ready.
+Must be the first component applied — no pods will schedule until Cilium removes the `node.cilium.io/agent-not-ready` taint it sets via `patches/cluster/30-cilium-prep.yaml`.
+
+Gateway API CRDs must be installed for `gatewayAPI.enabled: true` to work. The `gateway` Kustomization depends on Cilium, not the other way around.
 
 ## Ingress / Endpoints
 
-Hubble UI is available in-cluster. Gateway API gateway can be created from `policies/`.
+- **Hubble UI:** routed via Gateway API HTTPRoute at `hubble.${domain}` (see `hubble-httproute.yaml`)
+- **LoadBalancer pool:** `10.50.0.230–10.50.0.239` (see `policies/ipPool.yaml`)
+- **L2 announcement interface:** `enp[12]s0.50` (VLAN 50 trunk interface pattern)
 
 ## Troubleshooting
 
-- **Pods stuck in `ContainerCreating`:** Cilium is not yet ready. Check `kubectl -n kube-system get pods -l app.kubernetes.io/name=cilium`.
-- **L2 announcements not working:** Check `CiliumL2AnnouncementPolicy` and `CiliumLoadBalancerIPPool` CRs in `policies/`.
-- **`kubeProxyReplacement` errors on Talos:** Ensure the Talos machineconfig has `network.kubespan` disabled and the correct `apiServerAddress`.
+**`cilium-envoy` pods Pending / `didn't have free ports`:**
+Another Cilium instance (typically the `kube-system` bootstrap) is holding `hostPort: 9964`. Remove the old install first; see Migration above.
+
+**Pods stuck in `ContainerCreating`:**
+Cilium agent is not yet Ready. Check `kubectl -n cilium get pods -l k8s-app=cilium`.
+
+**L2 announcements not working:**
+Verify `CiliumL2AnnouncementPolicy` and `CiliumLoadBalancerIPPool` CRs are present and that the interface regex in `policies/l2-policy.yaml` matches the node's VLAN 50 NIC name.
+
+**`kubeProxyReplacement` errors on Talos:**
+Ensure `network.kubespan` is disabled in the Talos machineconfig and the kubelet is not also running kube-proxy.
+
+**HelmRelease retry budget exhausted:**
+```bash
+flux reconcile helmrelease cilium -n cilium --reset
+```

--- a/kubernetes/infrastructure/cilium/hubble-httproute.yaml
+++ b/kubernetes/infrastructure/cilium/hubble-httproute.yaml
@@ -7,6 +7,7 @@ spec:
   parentRefs:
     - name: orion
       namespace: gateway
+      sectionName: https
   hostnames:
     - "hubble.${domain}"
   rules:

--- a/kubernetes/infrastructure/cilium/hubble-httproute.yaml
+++ b/kubernetes/infrastructure/cilium/hubble-httproute.yaml
@@ -1,0 +1,19 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: hubble-ui
+  namespace: cilium
+spec:
+  parentRefs:
+    - name: orion
+      namespace: gateway
+  hostnames:
+    - "hubble.${domain}"
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+      backendRefs:
+        - name: hubble-ui
+          port: 80

--- a/kubernetes/infrastructure/cilium/kustomization.yaml
+++ b/kubernetes/infrastructure/cilium/kustomization.yaml
@@ -8,6 +8,7 @@ resources:
   - policies/l2-policy.yaml
   - policies/ipPool.yaml
   - policies/network-policy.yaml
+  - hubble-httproute.yaml
 
 configMapGenerator:
 - name: cilium-helm-chart-values

--- a/kubernetes/infrastructure/cilium/namespace.yaml
+++ b/kubernetes/infrastructure/cilium/namespace.yaml
@@ -6,3 +6,4 @@ metadata:
     pod-security.kubernetes.io/enforce: privileged
     pod-security.kubernetes.io/audit: privileged
     pod-security.kubernetes.io/warn: privileged
+    gateway.networking.k8s.io/access: "true"

--- a/kubernetes/infrastructure/cilium/policies/ipPool.yaml
+++ b/kubernetes/infrastructure/cilium/policies/ipPool.yaml
@@ -4,5 +4,5 @@ metadata:
   name: "pool"
 spec:
   blocks:
-    - start: "192.168.2.230"
-      stop: "192.168.2.239"
+    - start: "10.50.0.230"
+      stop: "10.50.0.239"

--- a/kubernetes/infrastructure/cilium/policies/l2-policy.yaml
+++ b/kubernetes/infrastructure/cilium/policies/l2-policy.yaml
@@ -6,4 +6,4 @@ spec:
   externalIPs: true
   loadBalancerIPs: true
   interfaces:
-    - enp1s0
+    - ^enp[12]s0\.50$

--- a/kubernetes/infrastructure/cilium/values.yaml
+++ b/kubernetes/infrastructure/cilium/values.yaml
@@ -30,7 +30,7 @@ gatewayAPI:
   enableAlpn: true
   enableAppProtocol: true
   hostNetwork:
-    enabled: true
+    enabled: false
 # for clusters with a single node
 operator:
   replicas: 1
@@ -45,8 +45,10 @@ hubble:
     #   ingressClassName: cilium
 # hostFirewall:
 #   enabled: true
-# ingressController:
-#   enabled: true
+ingressController:
+  enabled: true
+  loadbalancerMode: shared
+  default: false
 
 # L2 Announcements
 # enableL2Announcements: true
@@ -55,8 +57,6 @@ l2announcements:
   leaseDuration: 3s
   leaseRenewDeadline: 1s
   leaseRetryPeriod: 200ms
-k8sClientQps: {QPS}
-k8sClientBurst: {BURST}
 tls:
   secretsNamespace:
     name: "cilium"

--- a/kubernetes/infrastructure/gateway/certificate.yaml
+++ b/kubernetes/infrastructure/gateway/certificate.yaml
@@ -1,0 +1,15 @@
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: wildcard-orion-tls
+  # Must live in the cilium namespace to match tls.secretsNamespace in Cilium values
+  namespace: cilium
+spec:
+  secretName: wildcard-orion-tls
+  issuerRef:
+    name: letsencrypt-prod
+    kind: ClusterIssuer
+  commonName: "*.${domain}"
+  dnsNames:
+    - "*.${domain}"
+    - "${domain}"

--- a/kubernetes/infrastructure/gateway/gateway.yaml
+++ b/kubernetes/infrastructure/gateway/gateway.yaml
@@ -1,0 +1,29 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: orion
+  namespace: gateway
+  annotations:
+    io.cilium/lb-ipam-ips: "10.50.0.230"
+spec:
+  gatewayClassName: cilium
+  listeners:
+    - name: http
+      protocol: HTTP
+      port: 80
+      allowedRoutes:
+        namespaces:
+          from: All
+    - name: https
+      protocol: HTTPS
+      port: 443
+      hostname: "*.${domain}"
+      tls:
+        mode: Terminate
+        certificateRefs:
+          - kind: Secret
+            name: wildcard-orion-tls
+            namespace: cilium
+      allowedRoutes:
+        namespaces:
+          from: All

--- a/kubernetes/infrastructure/gateway/gateway.yaml
+++ b/kubernetes/infrastructure/gateway/gateway.yaml
@@ -13,7 +13,10 @@ spec:
       port: 80
       allowedRoutes:
         namespaces:
-          from: All
+          from: Selector
+          selector:
+            matchLabels:
+              gateway.networking.k8s.io/access: "true"
     - name: https
       protocol: HTTPS
       port: 443
@@ -26,4 +29,7 @@ spec:
             namespace: cilium
       allowedRoutes:
         namespaces:
-          from: All
+          from: Selector
+          selector:
+            matchLabels:
+              gateway.networking.k8s.io/access: "true"

--- a/kubernetes/infrastructure/gateway/kustomization.yaml
+++ b/kubernetes/infrastructure/gateway/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - namespace.yaml
+  - certificate.yaml
+  - gateway.yaml

--- a/kubernetes/infrastructure/gateway/namespace.yaml
+++ b/kubernetes/infrastructure/gateway/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: gateway

--- a/kubernetes/infrastructure/gateway/namespace.yaml
+++ b/kubernetes/infrastructure/gateway/namespace.yaml
@@ -2,3 +2,5 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: gateway
+  labels:
+    gateway.networking.k8s.io/access: "true"

--- a/kubernetes/infrastructure/vkms/release.yaml
+++ b/kubernetes/infrastructure/vkms/release.yaml
@@ -8,7 +8,7 @@ spec:
   releaseName: vkms
   upgrade:
     remediation:
-      remediateLastHelmReleaseRevision: true
+      retries: 3
   chart:
     spec:
       chart: victoria-metrics-k8s-stack

--- a/kubernetes/infrastructure/vkms/repository.yaml
+++ b/kubernetes/infrastructure/vkms/repository.yaml
@@ -1,4 +1,4 @@
-apiVersion: source.toolkit.fluxcd.io/v1beta2
+apiVersion: source.toolkit.fluxcd.io/v1
 kind: HelmRepository
 metadata:
   name: vkms

--- a/kubernetes/infrastructure/vkms/values.yaml
+++ b/kubernetes/infrastructure/vkms/values.yaml
@@ -8,8 +8,14 @@ grafana:
   ingress:
     enabled: true
     ingressClassName: cilium
+    annotations:
+      cert-manager.io/cluster-issuer: letsencrypt-prod
     hosts:
       - "grafana.${domain}"
+    tls:
+      - secretName: grafana-tls
+        hosts:
+          - "grafana.${domain}"
 vmagent:
   ingress:
     enabled: true


### PR DESCRIPTION
…oller

- Add Cilium Gateway (pinned VIP 10.50.0.230) with wildcard TLS via cert-manager + Let's Encrypt prod/Cloudflare DNS-01
- Add Hubble UI HTTPRoute as the canonical Gateway API example
- Enable Cilium ingressController (shared LB mode) so vkms Ingresses actually serve; add TLS to Grafana Ingress
- Wire cert-manager Flux Kustomizations into orion
- Fix gatewayAPI.hostNetwork → LB Service mode for stable VIP
- Fix unsubstituted {QPS}/{BURST} placeholders in Cilium values
- Correct L2 pool to 10.50.0.230-239 and l2-policy interface regex to match VLAN-50 sub-interfaces on both CP (enp2s0.50) and worker (enp1s0.50) hardware

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enabled automated TLS management and added wildcard certificate issuance
  * Added gateway routing with HTTP/HTTPS listeners for wildcard domains
  * Exposed monitoring UI via a Gateway HTTPRoute

* **Chores**
  * Updated cluster IP ranges and load‑balancer IP
  * Adjusted network interface selectors and load‑balancer pool
  * Disabled hostNetwork and added ingress controller config
  * Updated Flux/Helm manifest API versions and local reconcile workflow

* **Documentation**
  * Expanded Cilium rollout and operational guidance
<!-- end of auto-generated comment: release notes by coderabbit.ai -->