### PR TITLE
fix(orion): add missing dependsOn cluster-settings to cert-manager-issuers and vkms

### DIFF
--- a/kubernetes/clusters/orion/cert-manager.yaml
+++ b/kubernetes/clusters/orion/cert-manager.yaml
@@ -27,6 +27,7 @@ metadata:
 spec:
   dependsOn:
     - name: cert-manager
+    - name: cluster-settings
   interval: 10m
   retryInterval: 30s
   timeout: 1m30s

--- a/kubernetes/clusters/orion/vkms.yaml
+++ b/kubernetes/clusters/orion/vkms.yaml
@@ -4,6 +4,8 @@ metadata:
   name: vkms
   namespace: flux-system
 spec:
+  dependsOn:
+    - name: cluster-settings
   interval: 10m
   retryInterval: 30s
   timeout: 5m


### PR DESCRIPTION
## Summary

- `cert-manager-issuers` used `substituteFrom: cluster-settings` but only declared `dependsOn: cert-manager`, missing the dependency on the `cluster-settings` Kustomization
- `vkms` used `substituteFrom: cluster-settings` but had no `dependsOn` at all
- On a fresh cluster bootstrap (or Flux restart), both could reconcile before the `cluster-settings` ConfigMap existed and fail variable substitution

## Test plan

- [ ] Confirm `flux get kustomizations -A` shows `cert-manager-issuers` and `vkms` both waiting on `cluster-settings` before reconciling on next sync
- [ ] Verify no `unable to find variable` errors in Flux controller logs after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated deployment configuration dependencies to ensure system components initialize in the correct order, improving infrastructure reliability and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->