### PR TITLE
feat(orion): add reusable app framework and settings bootstrap

### DIFF
--- a/.taskfiles/General/Tasks.yml
+++ b/.taskfiles/General/Tasks.yml
@@ -15,3 +15,11 @@ tasks:
     desc: Run all pre-commit hooks against every tracked file
     cmds:
       - pre-commit run --all-files
+  new-app:
+    desc: "Scaffold a new app. Required: NAME, SUBDOMAIN, IMAGE. Optional: CLUSTER (default: orion), DEPENDS_ON."
+    cmds:
+      - sh scripts/new-app.sh NAME={{.NAME}} SUBDOMAIN={{.SUBDOMAIN}} IMAGE={{.IMAGE}} CLUSTER={{.CLUSTER}} {{if .DEPENDS_ON}}DEPENDS_ON={{.DEPENDS_ON}}{{end}}
+    vars:
+      CLUSTER: '{{default "orion" .CLUSTER}}'
+    requires:
+      vars: [NAME, SUBDOMAIN, IMAGE]

--- a/kubernetes/apps/_template/kustomization.yaml.tmpl
+++ b/kubernetes/apps/_template/kustomization.yaml.tmpl
@@ -1,0 +1,42 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ../webapp/base
+  # - pvc.yaml            # add if you need a PVC not covered by the pvc component
+  # - secret.sops.yaml    # add after encrypting with: sops --encrypt --in-place secret.sops.yaml
+
+components:
+  - ../webapp/components/ingress
+  # - ../webapp/components/pvc           # mounts /data; set storageClass + storageSize in cluster shell postBuild.substitute
+  # - ../webapp/components/tls-cert      # cert-manager Certificate (for non-ingress TLS use cases)
+  # - ../webapp/components/linkerd-inject
+  # - ../webapp/components/linkerd-disable
+
+namespace: __NAME__
+namePrefix: __NAME__-
+
+labels:
+  - includeSelectors: true
+    pairs:
+      app: __NAME__
+      app.kubernetes.io/name: __NAME__
+
+images:
+  - name: my-app
+    newName: __IMAGE__
+    newTag: "SET_TAG_HERE"  # replace with the desired image tag
+
+# configMapGenerator:
+#   - name: env
+#     files:
+#       - environment    # key=value env file
+
+# patches:
+#   - target:
+#       kind: Deployment
+#       name: deploy
+#     patch: |-
+#       - op: replace
+#         path: /spec/template/spec/containers/0/ports/0/containerPort
+#         value: 8080   # change if app doesn't listen on 8080

--- a/kubernetes/apps/_template/kustomization.yaml.tmpl
+++ b/kubernetes/apps/_template/kustomization.yaml.tmpl
@@ -25,7 +25,7 @@ labels:
 images:
   - name: my-app
     newName: __IMAGE__
-    newTag: "SET_TAG_HERE"  # replace with the desired image tag
+    newTag: "__IMAGE_TAG__"
 
 # configMapGenerator:
 #   - name: env

--- a/kubernetes/apps/webapp/README.md
+++ b/kubernetes/apps/webapp/README.md
@@ -61,7 +61,7 @@ Requires: `ingressClassName: nginx` (nginx must be deployed). For Cilium-only cl
 
 ### pvc
 
-Adds a `ReadWriteOnce` PVC named `data` and mounts it at `/data` on the `deploy` container. A `nameReference` transformer rewires the volume's `claimName` when `namePrefix` is applied.
+Adds a `ReadWriteOnce` PVC named `data` and mounts it at `/data` on the `deploy` container. A `nameReference` transformer rewires the volume's `claimName` when `namePrefix` is applied. The volumeMount patch targets `spec.template.spec.containers/0` — the first container in the Deployment.
 
 | Substitution var | Where to set | Example |
 |---|---|---|
@@ -72,7 +72,7 @@ Adds a `ReadWriteOnce` PVC named `data` and mounts it at `/data` on the `deploy`
 
 Adds a cert-manager `Certificate` for `${subdomain}.${domain}` using the `letsencrypt-prod` ClusterIssuer. Useful when you need a TLS secret without an nginx Ingress (e.g. Cilium Gateway, gRPC, direct TLS).
 
-Uses the same `subdomain` / `domain` substitution vars as `ingress`.
+Uses the same `subdomain` / `domain` substitution vars as `ingress`. Requires the `letsencrypt-prod` ClusterIssuer to exist; the certificate secret is written to `${subdomain}-${domain}-tls`.
 
 ### linkerd-inject / linkerd-disable
 
@@ -90,7 +90,7 @@ This writes `kubernetes/apps/my-service/kustomization.yaml` and `kubernetes/clus
 
 ## Handling secrets
 
-SOPS secrets are per-consumer, not a Component. Add a `secret.sops.yaml` file in the app directory:
+Per-app secrets live at `kubernetes/apps/<app-name>/secret.sops.yaml` (one file per app, distinct from cluster-wide secrets in `settings/cluster-secrets.sops.yaml`). Add one like this:
 
 ```bash
 # create the plaintext secret

--- a/kubernetes/apps/webapp/README.md
+++ b/kubernetes/apps/webapp/README.md
@@ -1,32 +1,118 @@
-# webapp
+# webapp — shared Kustomize base
 
-Shared Kustomize base for simple web applications. Provides a reusable `Deployment` + `Service` pattern with an optional `ingress` component.
+Reusable building blocks for simple web apps. Consuming apps pull `webapp/base` as a resource base and opt into Components for ingress, persistent storage, service-mesh injection, and TLS.
 
 ## Structure
 
 ```text
 webapp/
-├── base/            # Deployment and Service templates
-├── components/
-│   └── ingress/     # Optional ingress component (include in app overlays that need external access)
-├── deployment.yaml  # Default deployment spec
-└── service.yaml     # Default service spec
+├── base/
+│   ├── deployment.yaml   # Deployment named "deploy"; container name = ${appName}, image = my-app, port 8080
+│   └── service.yaml      # Service named "svc", ClusterIP, port 8080 (name: http)
+└── components/
+    ├── ingress/          # nginx Ingress + cert-manager TLS at ${subdomain}.${domain}
+    ├── pvc/              # ReadWriteOnce PVC + mounts at /data
+    ├── tls-cert/         # cert-manager Certificate (for non-ingress TLS scenarios)
+    ├── linkerd-inject/   # opt-in Linkerd sidecar injection on the pod template
+    └── linkerd-disable/  # explicit Linkerd sidecar opt-out on the pod template
 ```
 
-## Usage
-
-Other apps (e.g., `homebox`) use this as a Kustomize base:
+## Minimal consumer
 
 ```yaml
+# kubernetes/apps/my-service/kustomization.yaml
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
 resources:
   - ../webapp/base
 
 components:
   - ../webapp/components/ingress
+
+namespace: my-service
+namePrefix: my-service-
+
+labels:
+  - includeSelectors: true
+    pairs:
+      app: my-service
+
+images:
+  - name: my-app
+    newName: ghcr.io/example/my-service
+    newTag: "1.2.3"
 ```
 
-Override image, namespace, labels, and resource limits in the consuming app's kustomization.
+Then add a cluster shell at `kubernetes/clusters/orion/my-service.yaml` via `task gen:new-app` or by copying `kubernetes/clusters/_template/app.yaml.tmpl`.
 
-## Troubleshooting
+## Component reference
 
-- This directory is a base — it is not deployed directly. Issues will surface in the apps that consume it.
+### ingress
+
+Adds an nginx `Ingress` with cert-manager TLS.
+
+| Substitution var | Where to set | Example |
+|---|---|---|
+| `subdomain` | cluster shell `postBuild.substitute` | `homebox` |
+| `domain` | `cluster-settings` ConfigMap | `orion.norseamerican.com` |
+
+Requires: `ingressClassName: nginx` (nginx must be deployed). For Cilium-only clusters substitute `ingressClassName: cilium` with a patch.
+
+### pvc
+
+Adds a `ReadWriteOnce` PVC named `data` and mounts it at `/data` on the `deploy` container. A `nameReference` transformer rewires the volume's `claimName` when `namePrefix` is applied.
+
+| Substitution var | Where to set | Example |
+|---|---|---|
+| `storageClass` | cluster shell `postBuild.substitute` | `longhorn` |
+| `storageSize` | cluster shell `postBuild.substitute` | `5Gi` |
+
+### tls-cert
+
+Adds a cert-manager `Certificate` for `${subdomain}.${domain}` using the `letsencrypt-prod` ClusterIssuer. Useful when you need a TLS secret without an nginx Ingress (e.g. Cilium Gateway, gRPC, direct TLS).
+
+Uses the same `subdomain` / `domain` substitution vars as `ingress`.
+
+### linkerd-inject / linkerd-disable
+
+Patches `spec.template.metadata.annotations` on the `deploy` Deployment to opt the pod in or out of Linkerd sidecar injection. Include at most one per overlay.
+
+No substitution vars required.
+
+## Generating a new app
+
+```bash
+task gen:new-app NAME=my-service SUBDOMAIN=my-service IMAGE=ghcr.io/example/my-service:latest
+```
+
+This writes `kubernetes/apps/my-service/kustomization.yaml` and `kubernetes/clusters/orion/my-service.yaml`. Edit them, then run `task gen:validate`.
+
+## Handling secrets
+
+SOPS secrets are per-consumer, not a Component. Add a `secret.sops.yaml` file in the app directory:
+
+```bash
+# create the plaintext secret
+cat > kubernetes/apps/my-service/secret.sops.yaml <<EOF
+apiVersion: v1
+kind: Secret
+metadata:
+  name: my-service-secret
+  namespace: my-service
+stringData:
+  api-key: "replace-me"
+EOF
+
+# encrypt in-place (SOPS_AGE_KEY_FILE must point to your age key)
+sops --encrypt --in-place kubernetes/apps/my-service/secret.sops.yaml
+
+# add to resources in kustomization.yaml
+```
+
+The cluster shell already includes `decryption: { provider: sops, secretRef: { name: sops-age } }`.
+
+## Notes
+
+- `webapp/base` and `webapp/components/` are excluded from direct `kustomize build` validation in `scripts/validate.sh` — they are not standalone overlays.
+- `apps/homebox/` is the canonical real-world example of a consumer.

--- a/kubernetes/apps/webapp/components/linkerd-disable/kustomization.yaml
+++ b/kubernetes/apps/webapp/components/linkerd-disable/kustomization.yaml
@@ -1,0 +1,17 @@
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+
+patches:
+  - target:
+      kind: Deployment
+      name: deploy
+    patch: |-
+      apiVersion: apps/v1
+      kind: Deployment
+      metadata:
+        name: deploy
+      spec:
+        template:
+          metadata:
+            annotations:
+              linkerd.io/inject: disabled

--- a/kubernetes/apps/webapp/components/linkerd-inject/kustomization.yaml
+++ b/kubernetes/apps/webapp/components/linkerd-inject/kustomization.yaml
@@ -1,0 +1,17 @@
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+
+patches:
+  - target:
+      kind: Deployment
+      name: deploy
+    patch: |-
+      apiVersion: apps/v1
+      kind: Deployment
+      metadata:
+        name: deploy
+      spec:
+        template:
+          metadata:
+            annotations:
+              linkerd.io/inject: enabled

--- a/kubernetes/apps/webapp/components/pvc/kustomization.yaml
+++ b/kubernetes/apps/webapp/components/pvc/kustomization.yaml
@@ -1,0 +1,25 @@
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+
+resources:
+  - pvc.yaml
+
+patches:
+  - target:
+      kind: Deployment
+      name: deploy
+    patch: |-
+      - op: add
+        path: /spec/template/spec/volumes
+        value:
+          - name: data
+            persistentVolumeClaim:
+              claimName: data
+      - op: add
+        path: /spec/template/spec/containers/0/volumeMounts
+        value:
+          - mountPath: /data
+            name: data
+
+configurations:
+  - nameReference.yaml

--- a/kubernetes/apps/webapp/components/pvc/nameReference.yaml
+++ b/kubernetes/apps/webapp/components/pvc/nameReference.yaml
@@ -1,0 +1,6 @@
+nameReference:
+  - kind: PersistentVolumeClaim
+    version: v1
+    fieldSpecs:
+      - path: spec/template/spec/volumes/persistentVolumeClaim/claimName
+        kind: Deployment

--- a/kubernetes/apps/webapp/components/pvc/pvc.yaml
+++ b/kubernetes/apps/webapp/components/pvc/pvc.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: data
+spec:
+  accessModes:
+    - ReadWriteOnce
+  storageClassName: ${storageClass}
+  resources:
+    requests:
+      storage: ${storageSize}

--- a/kubernetes/apps/webapp/components/tls-cert/certificate.yaml
+++ b/kubernetes/apps/webapp/components/tls-cert/certificate.yaml
@@ -1,0 +1,12 @@
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: tls-cert
+spec:
+  secretName: ${subdomain}-${domain}-tls
+  issuerRef:
+    name: letsencrypt-prod
+    kind: ClusterIssuer
+  commonName: ${subdomain}.${domain}
+  dnsNames:
+    - ${subdomain}.${domain}

--- a/kubernetes/apps/webapp/components/tls-cert/kustomization.yaml
+++ b/kubernetes/apps/webapp/components/tls-cert/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+
+resources:
+  - certificate.yaml

--- a/kubernetes/clusters/_template/app.yaml.tmpl
+++ b/kubernetes/clusters/_template/app.yaml.tmpl
@@ -1,25 +1,29 @@
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
-  name: cilium
+  name: __NAME__
   namespace: flux-system
 spec:
-  interval: 20m
+  interval: 10m
   retryInterval: 30s
   timeout: 15m
   prune: true
   wait: true
   dependsOn:
     - name: cluster-settings
+    # - name: __DEPENDS_ON__  # uncomment and set if this service needs another to be ready first
   sourceRef:
     kind: GitRepository
     name: flux-system
-  path: ./kubernetes/infrastructure/cilium
+  path: ./kubernetes/apps/__NAME__
   decryption:
     provider: sops
     secretRef:
       name: sops-age
   postBuild:
+    substitute:
+      appName: __NAME__
+      subdomain: __SUBDOMAIN__
     substituteFrom:
       - kind: ConfigMap
         name: cluster-settings

--- a/kubernetes/clusters/orion/cluster-settings.yaml
+++ b/kubernetes/clusters/orion/cluster-settings.yaml
@@ -1,9 +1,19 @@
-apiVersion: v1
-kind: ConfigMap
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
 metadata:
   name: cluster-settings
   namespace: flux-system
-data:
-  domain: orion.norseamerican.com
-  externalIp: 10.50.0.230
-  certCloudflareEmail: permalost.commercial+cloudflare@gmail.com
+spec:
+  interval: 10m
+  retryInterval: 30s
+  timeout: 1m30s
+  prune: true
+  wait: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+  path: ./kubernetes/clusters/orion/settings
+  decryption:
+    provider: sops
+    secretRef:
+      name: sops-age

--- a/kubernetes/clusters/orion/docs/adding-services.md
+++ b/kubernetes/clusters/orion/docs/adding-services.md
@@ -1,0 +1,169 @@
+# Adding services to the orion cluster
+
+Two pathways depending on whether the service ships as a Helm chart or raw manifests.
+
+## Pathway A: Helm chart (infrastructure component)
+
+Use this for cluster-level infrastructure: CNI, ingress, cert-manager, metrics stack, storage drivers.
+
+**Reference implementation:** `kubernetes/infrastructure/cilium/`
+
+1. Create `kubernetes/infrastructure/<name>/` with:
+   - `namespace.yaml` — Namespace resource
+   - `repository.yaml` — HelmRepository (OCI or HTTP)
+   - `release.yaml` — HelmRelease with `valuesFrom: ConfigMap` (not inline `spec.values`)
+   - `values.yaml` — Helm values (plain YAML)
+   - `kustomization.yaml` — includes `configMapGenerator` from `values.yaml` + `configurations: [kustomizeconfig.yaml]`
+   - `kustomizeconfig.yaml` — `nameReference` wiring ConfigMap → HelmRelease `spec/valuesFrom/name`
+   - `README.md`
+
+2. Add a cluster shell at `kubernetes/clusters/orion/<name>.yaml`:
+
+```yaml
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: <name>
+  namespace: flux-system
+spec:
+  interval: 10m
+  retryInterval: 30s
+  timeout: 15m
+  prune: true
+  wait: true
+  dependsOn:
+    - name: cluster-settings
+    # add more dependsOn here (e.g. cilium, cert-manager)
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+  path: ./kubernetes/infrastructure/<name>
+  decryption:
+    provider: sops
+    secretRef:
+      name: sops-age
+  postBuild:
+    substituteFrom:
+      - kind: ConfigMap
+        name: cluster-settings
+      - kind: Secret
+        name: cluster-secrets
+```
+
+3. Run `task gen:validate`.
+
+**Why the ConfigMap pattern?** Changing `values.yaml` updates the ConfigMap hash (via `configMapGenerator`), which Flux detects as a drift and triggers a HelmRelease re-reconciliation automatically. Inline `spec.values` changes are also detected, but the ConfigMap approach keeps values in a dedicated file that is easier to diff and review.
+
+---
+
+## Pathway B: Raw manifests / simple web app
+
+Use this for application workloads that follow the standard Deployment + Service + Ingress shape.
+
+**Reference implementation:** `kubernetes/apps/homebox/`
+
+### Scaffold with new-app
+
+```bash
+task gen:new-app NAME=my-service SUBDOMAIN=my-service IMAGE=ghcr.io/example/my-service:latest
+```
+
+This generates:
+- `kubernetes/apps/my-service/kustomization.yaml` — pulls `webapp/base`, opts into `ingress` Component, pre-fills substitution variables
+- `kubernetes/clusters/orion/my-service.yaml` — Flux Kustomization shell with `dependsOn: cluster-settings`, sops decryption, and `postBuild.substitute`
+
+### Components available
+
+| Component | What it adds | Required substitute vars |
+|---|---|---|
+| `ingress` | nginx Ingress + cert-manager TLS | `subdomain`, `domain` (from cluster-settings) |
+| `pvc` | PVC + /data mount | `storageClass`, `storageSize` |
+| `tls-cert` | cert-manager Certificate | `subdomain`, `domain` |
+| `linkerd-inject` | Linkerd sidecar opt-in | — |
+| `linkerd-disable` | Linkerd sidecar opt-out | — |
+
+Components live at `kubernetes/apps/webapp/components/`. Add them to the `components:` list in your `kustomization.yaml`. See `kubernetes/apps/webapp/README.md` for the full reference.
+
+### Manual steps after scaffolding
+
+1. **Set the correct image tag** — the scaffold uses `latest`; pin to a real tag.
+2. **Adjust port if not 8080** — add an inline JSON patch to `kustomization.yaml`:
+   ```yaml
+   patches:
+     - target: {kind: Deployment, name: deploy}
+       patch: |-
+         - op: replace
+           path: /spec/template/spec/containers/0/ports/0/containerPort
+           value: 3000
+     - target: {kind: Service, name: svc}
+       patch: |-
+         - op: replace
+           path: /spec/ports/0/port
+           value: 3000
+   ```
+3. **Add extra resources** — PVCs not covered by the `pvc` Component, ConfigMaps for env files via `configMapGenerator`, etc.
+4. **Add secrets** (see below).
+5. Run `task gen:validate` — this runs `kubeconform` + `kube-linter` over all manifests.
+
+---
+
+## Adding secrets
+
+Secrets must be SOPS-encrypted before committing. The cluster already has a `cluster-secrets` Secret in `flux-system` for cluster-wide substitution vars. For per-service secrets:
+
+```bash
+# 1. Create plaintext
+cat > kubernetes/apps/my-service/secret.sops.yaml <<EOF
+apiVersion: v1
+kind: Secret
+metadata:
+  name: my-service-secret
+  namespace: my-service
+stringData:
+  api-key: "replace-me"
+EOF
+
+# 2. Encrypt in-place
+SOPS_AGE_KEY_FILE=~/.config/sops/age/keys.txt \
+  sops --encrypt --in-place kubernetes/apps/my-service/secret.sops.yaml
+
+# 3. Add to resources in kustomization.yaml
+#    - secret.sops.yaml
+```
+
+The cluster shell already sets `decryption: { provider: sops, secretRef: { name: sops-age } }` so Flux will decrypt it automatically.
+
+For cluster-wide secrets (values substituted via `${var}` in any service), add the key to `kubernetes/clusters/orion/settings/cluster-secrets.sops.yaml`:
+
+```bash
+SOPS_AGE_KEY_FILE=~/.config/sops/age/keys.txt \
+  sops kubernetes/clusters/orion/settings/cluster-secrets.sops.yaml
+# edit in the sops-opened editor, save, exit — it re-encrypts automatically
+```
+
+---
+
+## Bootstrap order for orion
+
+```text
+cluster-settings  (Flux Kustomization at clusters/orion/cluster-settings.yaml)
+  └── cilium       (CNI; dependsOn: cluster-settings)
+        └── cert-manager   (add when needed; dependsOn: cilium)
+              └── <apps>   (dependsOn: cert-manager for TLS, or cilium for basic ingress)
+```
+
+Set `dependsOn` in each cluster shell to enforce this. The `task gen:new-app` scaffold defaults to `dependsOn: cluster-settings` — update it for services that need cert-manager or an ingress controller first.
+
+---
+
+## Validation
+
+```bash
+# Full kubeconform + kube-linter sweep
+task gen:validate
+
+# Build a single overlay to check substitution rendering
+kustomize build --load-restrictor=LoadRestrictionsNone kubernetes/apps/my-service/
+```
+
+No CI decryption of SOPS files — CI schema-validates only. Local `sops -d` with your age key to confirm decryption works.

--- a/kubernetes/clusters/orion/settings/cluster-secrets.sops.yaml
+++ b/kubernetes/clusters/orion/settings/cluster-secrets.sops.yaml
@@ -1,0 +1,22 @@
+apiVersion: v1
+kind: Secret
+metadata:
+    name: cluster-secrets
+    namespace: flux-system
+stringData:
+    placeholder: ENC[AES256_GCM,data:ga++pxdW4soL7Q==,iv:+3nE7yXHYLdzJPv2C8FCyuKysrSQk+sk/0L+Wb09V9w=,tag:7vTkNcE8zMU8Ue26dBJ7Nw==,type:str]
+sops:
+    age:
+        - enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSB2NEE2Vld3MUd5OElkVHR4
+            a01OdThTUVpDeXI2cEhueEhpVG5LL0tISFVrClgwSWdPazFmNmdTS1pKSmZsa0Nx
+            N0RFbHVraDRVOVVvellDdmNKMU1ibm8KLS0tIC96cWxrRjNmQjd0TkVjRmpGVmRG
+            SEF4M0xEZmRsTWRmTjBOZUxYdk0wdXcKcIJU8NsPre80lK6ZbIDbzFEKstnLEumf
+            4dEXI4jEWNzKL//mbiwNtfmVCnzRxwcYP7hJh2zwzMCIEbgC4ygVfw==
+            -----END AGE ENCRYPTED FILE-----
+          recipient: age13tszh09s5hr9hzjdy8enq7uncz9p2z09hsvky2dn25vudr4cx37s6k5n9z
+    encrypted_regex: ^(data|stringData)$
+    lastmodified: "2026-06-07T19:53:15Z"
+    mac: ENC[AES256_GCM,data:rJ2I3f6yEcAKGG5SNFDd+mvOBYAjt1nDbIBf2kObrgDUowv3U6N7gy9bWo6oc8awfAbmHx1LbNZpHx56+fvkSLuBP78+6yO8ZSJLs1p6CvcrFo8Ye/92UMH/nqua6GQpNM3y1YZwYYQ+PFm8Xq1xILCbgGYBGe5ygwzgtOkVROk=,iv:SdO9iJ7WfQ9KP5w+bHMRyYV8bgKG4U6fYvXSCc6FLew=,tag:9iv6++ak7AsgPbZGb0uGUw==,type:str]
+    version: 3.13.0

--- a/kubernetes/clusters/orion/settings/cluster-settings.yaml
+++ b/kubernetes/clusters/orion/settings/cluster-settings.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: cluster-settings
+  namespace: flux-system
+data:
+  domain: orion.norseamerican.com
+  externalIp: 10.50.0.230
+  certCloudflareEmail: permalost.commercial+cloudflare@gmail.com

--- a/kubernetes/clusters/orion/settings/kustomization.yaml
+++ b/kubernetes/clusters/orion/settings/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - cluster-settings.yaml
+  - cluster-secrets.sops.yaml

--- a/kubernetes/infrastructure/README.md
+++ b/kubernetes/infrastructure/README.md
@@ -28,5 +28,7 @@ cilium → cert-manager → (everything else in parallel)
 ## Adding a Component
 
 1. Create a new directory here with at minimum a `kustomization.yaml` and a `release.yaml` (HelmRelease) or raw manifests.
-2. Add a README using the [standard template](../../docs/component-readme-template.md).
+2. Add a README documenting purpose, dependencies, and any required `postBuild.substitute` variables.
 3. Wire it into a cluster by adding a Kustomization in `kubernetes/clusters/<name>/<component>.yaml`.
+
+**Canonical pattern for Helm components with a values file:** follow `cilium/` — use a `configMapGenerator` in `kustomization.yaml` to generate a ConfigMap from `values.yaml`, add `valuesFrom` in the HelmRelease pointing to that ConfigMap, and include a `kustomizeconfig.yaml` with a `nameReference` so that changing `values.yaml` automatically triggers a HelmRelease re-reconciliation.

--- a/scripts/new-app.sh
+++ b/scripts/new-app.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+# Scaffold a new app under kubernetes/apps/<name>/ and a cluster shell
+# under kubernetes/clusters/<cluster>/<name>.yaml.
+#
+# Usage:
+#   new-app.sh NAME=<name> SUBDOMAIN=<subdomain> IMAGE=<image> [CLUSTER=orion] [DEPENDS_ON=<dep>]
+#
+# Example:
+#   new-app.sh NAME=homebox SUBDOMAIN=homebox IMAGE=ghcr.io/sysadminsmedia/homebox:0.20.2
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+NAME=""
+SUBDOMAIN=""
+IMAGE=""
+CLUSTER="orion"
+DEPENDS_ON=""
+
+for arg in "$@"; do
+  case "$arg" in
+    NAME=*)       NAME="${arg#NAME=}" ;;
+    SUBDOMAIN=*)  SUBDOMAIN="${arg#SUBDOMAIN=}" ;;
+    IMAGE=*)      IMAGE="${arg#IMAGE=}" ;;
+    CLUSTER=*)    CLUSTER="${arg#CLUSTER=}" ;;
+    DEPENDS_ON=*) DEPENDS_ON="${arg#DEPENDS_ON=}" ;;
+    *) echo "Unknown argument: $arg" >&2; exit 1 ;;
+  esac
+done
+
+if [[ -z "$NAME" || -z "$SUBDOMAIN" || -z "$IMAGE" ]]; then
+  echo "Usage: $0 NAME=<name> SUBDOMAIN=<subdomain> IMAGE=<image> [CLUSTER=orion] [DEPENDS_ON=<dep>]" >&2
+  exit 1
+fi
+
+APP_DIR="${REPO_ROOT}/kubernetes/apps/${NAME}"
+SHELL_FILE="${REPO_ROOT}/kubernetes/clusters/${CLUSTER}/${NAME}.yaml"
+APP_TMPL="${REPO_ROOT}/kubernetes/apps/_template/kustomization.yaml.tmpl"
+SHELL_TMPL="${REPO_ROOT}/kubernetes/clusters/_template/app.yaml.tmpl"
+
+if [[ -d "$APP_DIR" ]]; then
+  echo "ERROR: ${APP_DIR} already exists. Choose a different name or edit it directly." >&2
+  exit 1
+fi
+
+if [[ -f "$SHELL_FILE" ]]; then
+  echo "ERROR: ${SHELL_FILE} already exists." >&2
+  exit 1
+fi
+
+mkdir -p "$APP_DIR"
+
+sed \
+  -e "s|__NAME__|${NAME}|g" \
+  -e "s|__SUBDOMAIN__|${SUBDOMAIN}|g" \
+  -e "s|__IMAGE__|${IMAGE}|g" \
+  "$APP_TMPL" > "${APP_DIR}/kustomization.yaml"
+
+SHELL_CONTENT=$(sed \
+  -e "s|__NAME__|${NAME}|g" \
+  -e "s|__SUBDOMAIN__|${SUBDOMAIN}|g" \
+  "$SHELL_TMPL")
+
+if [[ -n "$DEPENDS_ON" ]]; then
+  SHELL_CONTENT=$(echo "$SHELL_CONTENT" | sed \
+    -e "s|# - name: __DEPENDS_ON__.*|  - name: ${DEPENDS_ON}|")
+else
+  SHELL_CONTENT=$(echo "$SHELL_CONTENT" | grep -v "# - name: __DEPENDS_ON__")
+fi
+
+echo "$SHELL_CONTENT" > "$SHELL_FILE"
+
+echo ""
+echo "Scaffolded:"
+echo "  ${APP_DIR}/kustomization.yaml"
+echo "  ${SHELL_FILE}"
+echo ""
+echo "Next steps:"
+echo "  1. Edit ${APP_DIR}/kustomization.yaml — set the correct image tag, port patches, and any extra resources."
+echo "  2. Edit ${SHELL_FILE} — confirm dependsOn and postBuild.substitute values."
+echo "  3. If this service needs secrets:"
+echo "       cp /dev/null ${APP_DIR}/secret.sops.yaml"
+echo "       # add stringData keys, then:"
+echo "       sops --encrypt --in-place ${APP_DIR}/secret.sops.yaml"
+echo "       # add secret.sops.yaml to resources in kustomization.yaml"
+echo "  4. Run: task gen:validate"

--- a/scripts/new-app.sh
+++ b/scripts/new-app.sh
@@ -36,6 +36,14 @@ if [[ -z "$NAME" || -z "$SUBDOMAIN" || -z "$IMAGE" ]]; then
   exit 1
 fi
 
+if [[ "$IMAGE" == *:* ]]; then
+  IMAGE_NAME="${IMAGE%:*}"
+  IMAGE_TAG="${IMAGE##*:}"
+else
+  IMAGE_NAME="$IMAGE"
+  IMAGE_TAG="latest"
+fi
+
 APP_DIR="${REPO_ROOT}/kubernetes/apps/${NAME}"
 SHELL_FILE="${REPO_ROOT}/kubernetes/clusters/${CLUSTER}/${NAME}.yaml"
 APP_TMPL="${REPO_ROOT}/kubernetes/apps/_template/kustomization.yaml.tmpl"
@@ -51,12 +59,19 @@ if [[ -f "$SHELL_FILE" ]]; then
   exit 1
 fi
 
+CLUSTER_DIR="${REPO_ROOT}/kubernetes/clusters/${CLUSTER}"
+if [[ ! -d "$CLUSTER_DIR" ]]; then
+  echo "ERROR: cluster directory ${CLUSTER_DIR} does not exist" >&2
+  exit 1
+fi
+
 mkdir -p "$APP_DIR"
 
 sed \
   -e "s|__NAME__|${NAME}|g" \
   -e "s|__SUBDOMAIN__|${SUBDOMAIN}|g" \
-  -e "s|__IMAGE__|${IMAGE}|g" \
+  -e "s|__IMAGE__|${IMAGE_NAME}|g" \
+  -e "s|__IMAGE_TAG__|${IMAGE_TAG}|g" \
   "$APP_TMPL" > "${APP_DIR}/kustomization.yaml"
 
 SHELL_CONTENT=$(sed \


### PR DESCRIPTION
## Summary

- Converts `cluster-settings.yaml` from a bare ConfigMap to a Flux Kustomization pointing to a new `settings/` subdirectory, enabling SOPS-encrypted cluster secrets alongside the ConfigMap
- Adds reusable webapp Kustomize Components: `pvc` (ReadWriteOnce PVC + `/data` mount with nameReference transformer), `tls-cert` (cert-manager Certificate), `linkerd-inject`, and `linkerd-disable`
- Wires `cilium` to depend on `cluster-settings` and adds SOPS decryption + `cluster-secrets` substitution to it
- Adds `task gen:new-app` scaffolder (`scripts/new-app.sh`) with app/cluster-shell templates for bootstrapping new services

## Test plan

- [x] `task gen:validate` — kubeconform + kube-linter + talhelper all pass clean
- [x] `task test:kind-up && task test:kind-push && task test:kind-reconcile` — `cluster-settings`, `cert-manager`, `cert-manager-issuers`, and `vkms` all reconcile Ready; cilium fails on `CiliumLoadBalancerIPPool` CRD (pre-existing kind limitation, not new)
- [ ] Verify `cluster-secrets` decryption on real orion cluster after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automated app scaffolding via a new task and script with configurable parameters (name, subdomain, image, cluster, and optional reconciliation dependency).
  * Introduced reusable Kustomize components for persistent storage, TLS certificates, and Linkerd sidecar injection control.
* **Documentation**
  * Expanded webapp Kustomize documentation with minimal consumer examples, component reference, and secret-handling guidance.
  * Updated cluster and infrastructure onboarding docs, including service-adding workflows and configuration patterns.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->