### PR TITLE
fix(vkms): use null storage to disable vmsingle PVC

### DIFF
--- a/kubernetes/infrastructure/vkms/values.yaml
+++ b/kubernetes/infrastructure/vkms/values.yaml
@@ -30,7 +30,7 @@ vmalert:
       - "vmalert.${domain}"
 vmsingle:
   spec:
-    storage: {}
+    storage: null
   ingress:
     enabled: true
     ingressClassName: cilium


### PR DESCRIPTION
storage: {} doesn't override the chart's default 20Gi PVC via Helm deep merge — the chart default wins. storage: null explicitly nullifies the field, causing the victoria-metrics-operator to use emptyDir instead.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Modified vmsingle storage configuration in Kubernetes Helm values file, changing from an empty object to null, which alters how storage is handled in the deployment configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->