### PR TITLE
fix(talos): add missing vip.ip to CP nodes on VLAN 50

### DIFF
--- a/clusters/orion/talconfig.yaml
+++ b/clusters/orion/talconfig.yaml
@@ -57,6 +57,8 @@ nodes:
             routes:
               - network: 0.0.0.0/0
                 gateway: 10.50.0.1
+            vip:
+              ip: 10.50.0.10
           - vlanId: 10
             mtu: 1500
             dhcp: false
@@ -82,6 +84,8 @@ nodes:
             routes:
               - network: 0.0.0.0/0
                 gateway: 10.50.0.1
+            vip:
+              ip: 10.50.0.10
           - vlanId: 10
             mtu: 1500
             dhcp: false
@@ -107,6 +111,8 @@ nodes:
             routes:
               - network: 0.0.0.0/0
                 gateway: 10.50.0.1
+            vip:
+              ip: 10.50.0.10
           - vlanId: 10
             mtu: 1500
             dhcp: false


### PR DESCRIPTION
The control-plane VIP (10.50.0.10) was documented in NODES.md as managed by Talos via vip.ip but was never committed to talconfig.yaml. It was presumably applied manually at cluster creation and lost during config regeneration.

Adding vip.ip: 10.50.0.10 to the vlanId: 50 interface on all three CP nodes (orion-cp-01/02/03). Workers do not carry the VIP.

Apply after merge: task talos:gen-config && task talos:apply-all