### PR TITLE
fix(cilium): always create GatewayClass instead of relying on auto-de…

### DIFF
--- a/kubernetes/infrastructure/cilium/values.yaml
+++ b/kubernetes/infrastructure/cilium/values.yaml
@@ -32,6 +32,8 @@ gatewayAPI:
   enabled: true
   enableAlpn: true
   enableAppProtocol: true
+  gatewayClass:
+    create: "true"
   hostNetwork:
     enabled: false
 # for clusters with a single node


### PR DESCRIPTION
…tection

gatewayClass.create defaults to 'auto', which conditionally creates the GatewayClass only if the CRD is detected at Helm render time. Since the Gateway API CRDs are now managed separately (gateway-api Kustomization), the timing of CRD registration vs Helm render is unreliable.

Setting create: "true" makes GatewayClass creation unconditional whenever gatewayAPI.enabled is true.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enabled Gateway API class creation in the networking infrastructure configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->