### PR TITLE
fix(cert-manager): update Cloudflare API token and remove deprecated …

### DIFF
--- a/kubernetes/infrastructure/cert-manager/issuers/cluster-issuer-prod.yaml
+++ b/kubernetes/infrastructure/cert-manager/issuers/cluster-issuer-prod.yaml
@@ -14,4 +14,3 @@ spec:
             apiTokenSecretRef:
               key: api-token
               name: cloudflare-secret
-            email: ${certCloudflareEmail}

--- a/kubernetes/infrastructure/cert-manager/issuers/cluster-issuer-staging.yaml
+++ b/kubernetes/infrastructure/cert-manager/issuers/cluster-issuer-staging.yaml
@@ -14,4 +14,3 @@ spec:
             apiTokenSecretRef:
               key: api-token
               name: cloudflare-secret
-            email: ${certCloudflareEmail}

--- a/kubernetes/infrastructure/cert-manager/secret.yaml
+++ b/kubernetes/infrastructure/cert-manager/secret.yaml
@@ -5,15 +5,10 @@ metadata:
     namespace: cert-manager
 type: Opaque
 stringData:
-    api-token: ENC[AES256_GCM,data:kW0C1lTyc8msPGudvSI7Tam8mqvLzTy/f0epBDFtmew5OZ8cpNVgIQ==,iv:4UCS7nCoPUy0MpO8vDvK33BLwcxxyK0/Y+VO52sK/H8=,tag:YiL14RFNNJZMrFDIUKG22g==,type:str]
+    api-token: ENC[AES256_GCM,data:GCtAOKiVHw/lcBDhaxFU5Ba6FINAGhKn4aOs7uoQo/xe40S2GMY8FATa2wIn1i5afPzVL7s=,iv:ZfVYRfJFd/3y1kqpoFynbZb1si7cpOtBZHgKF1M/sAM=,tag:gbJe3SdLBRjA4m9KWs6aeA==,type:str]
 sops:
-    kms: []
-    gcp_kms: []
-    azure_kv: []
-    hc_vault: []
     age:
-        - recipient: age13tszh09s5hr9hzjdy8enq7uncz9p2z09hsvky2dn25vudr4cx37s6k5n9z
-          enc: |
+        - enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
             YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSAvSkhKT3NCRm5UNTE0dzEy
             S0E5SVBpQU9xSzlsd29jRXlGNnJJNzQzU0JvCnlZMkdvVzg2d3RSdC9keG43Tkgr
@@ -21,8 +16,8 @@ sops:
             ZkdGbFFSQnF2RERnZm1QdWhrRnkvU2sKFaO1Kc7fe/yPg3AfD8TTuGKFVK2jj3Je
             hAZEsqh1BwWMLKobEO840YDwAuMlWKoLEGhU9b7Is1NkMoiERBEmaQ==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2025-02-04T19:35:42Z"
-    mac: ENC[AES256_GCM,data:sLloPGK6YRAFUdPX/JJEQaoe99ZwKYiLSjSCZ+C2lJLC4cEW0EpS5V5ZOGAHvyVBok1qOy66UyUJUSa2rVhNlNWq1hctY/lBwc8SZ+9Sld80iel+2YqfyOtttbmPCkt+mB0HGALnKY2G02wPVaE5z0NObVcxfdqyLvN16d+52CQ=,iv:wRhJZEWPCT5y0z8NgYi8fZj4xHmnVIlGY7r84H7PKxY=,tag:XStTPfjEnqGs+tF4yaXVZg==,type:str]
-    pgp: []
+          recipient: age13tszh09s5hr9hzjdy8enq7uncz9p2z09hsvky2dn25vudr4cx37s6k5n9z
     encrypted_regex: ^(data|stringData)$
-    version: 3.7.3
+    lastmodified: "2026-06-14T19:40:15Z"
+    mac: ENC[AES256_GCM,data:AVFaYBeIP41Idt3pjVg0ADGvUuKfDCThNcgzmaQaSlmcp8A5F3981he/dVC9VsfXFmBNBeGnj4fBkgfErTxTt3mucWS5UwPT9igBPzgiaT50CpoYIcKnetOddFPMCI2mUQx6yEfzSHvxHYT/avuTzlD5am00bLXgATz8uiGrK+0=,iv:SQmFbmKiDQHvztytYScrqnwicRzOTnkiSp2d4zVjqqg=,tag:bMK11jiCqhpaJQJEh7ubpw==,type:str]
+    version: 3.13.0


### PR DESCRIPTION
…email field

- New scoped API Token replaces the old Global API Key which caused Cloudflare 10502 auth failures. Token has Zone:DNS:Edit + Zone:Zone:Read permissions scoped to norseamerican.com.
- Remove email field from cloudflare solver block — only required for Global API Key (apiKeySecretRef), not for API Token (apiTokenSecretRef). The acme.email field (Let's Encrypt account) is retained.