### PR TITLE
fix(gateway): add ReferenceGrant for Gateway to read wildcard TLS secret

### DIFF
--- a/kubernetes/infrastructure/gateway/kustomization.yaml
+++ b/kubernetes/infrastructure/gateway/kustomization.yaml
@@ -5,3 +5,4 @@ resources:
   - certificate.yaml
   - gateway.yaml
   - hubble-httproute.yaml
+  - reference-grant.yaml

--- a/kubernetes/infrastructure/gateway/reference-grant.yaml
+++ b/kubernetes/infrastructure/gateway/reference-grant.yaml
@@ -1,0 +1,14 @@
+apiVersion: gateway.networking.k8s.io/v1beta1
+kind: ReferenceGrant
+metadata:
+  name: gateway-can-read-cilium-secrets
+  namespace: cilium
+spec:
+  from:
+    - group: gateway.networking.k8s.io
+      kind: Gateway
+      namespace: gateway
+  to:
+    - group: ""
+      kind: Secret
+      name: wildcard-orion-tls


### PR DESCRIPTION
The Gateway (gateway/orion) references wildcard-orion-tls Secret from the cilium namespace. Gateway API requires a ReferenceGrant in the cilium namespace permitting cross-namespace Secret reads, otherwise the TLS handshake resets with "connection reset by peer".