### PR TITLE
fix(external-dns): add --pihole-api-version=6 for pihole v6/FTL

### DIFF
--- a/kubernetes/infrastructure/external-dns/release.yaml
+++ b/kubernetes/infrastructure/external-dns/release.yaml
@@ -31,6 +31,7 @@ spec:
     policy: upsert-only
     extraArgs:
       - --pihole-server=http://pihole-svc.pihole.svc.cluster.local
+      - --pihole-api-version=6
     env:
       - name: EXTERNAL_DNS_PIHOLE_PASSWORD
         valueFrom:


### PR DESCRIPTION
ExternalDNS defaults to the pihole v5 API which returns 404 on pihole v6 (FTL). Adding --pihole-api-version=6 directs it to the correct v6 API.