### PR TITLE
feat(coredns): add stub zone for orion.norseamerican.com → pihole

### DIFF
--- a/kubernetes/clusters/orion/coredns.yaml
+++ b/kubernetes/clusters/orion/coredns.yaml
@@ -1,0 +1,21 @@
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: coredns
+  namespace: flux-system
+spec:
+  interval: 1h
+  retryInterval: 1m
+  timeout: 3m
+  prune: false
+  wait: true
+  dependsOn:
+    - name: cluster-settings
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+  path: ./kubernetes/infrastructure/coredns
+  postBuild:
+    substituteFrom:
+      - kind: ConfigMap
+        name: cluster-settings

--- a/kubernetes/infrastructure/coredns/coredns-patch.yaml
+++ b/kubernetes/infrastructure/coredns/coredns-patch.yaml
@@ -1,0 +1,38 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: coredns
+  namespace: kube-system
+data:
+  Corefile: |
+    .:53 {
+        errors
+        health {
+            lameduck 5s
+        }
+        ready
+        log . {
+            class error
+        }
+        prometheus :9153
+
+        kubernetes cluster.local in-addr.arpa ip6.arpa {
+            pods insecure
+            fallthrough in-addr.arpa ip6.arpa
+            ttl 30
+        }
+        forward . /etc/resolv.conf {
+           max_concurrent 1000
+        }
+        cache 30 {
+           disable success cluster.local
+           disable denial cluster.local
+        }
+        loop
+        reload
+        loadbalance
+    }
+    ${domain}:53 {
+        forward . ${externalDnsIp}
+        errors
+    }

--- a/kubernetes/infrastructure/coredns/kustomization.yaml
+++ b/kubernetes/infrastructure/coredns/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - coredns-patch.yaml


### PR DESCRIPTION
## Summary

- **Root cause found**: CoreDNS forwards all external queries to public DNS (1.1.1.1/8.8.8.8). The domain `norseamerican.com` has a public Cloudflare presence, so any pod querying `*.orion.norseamerican.com` gets back Cloudflare CDN IPs instead of the internal gateway VIP `10.50.0.231`.
- **What is working**: BGP is established (731h uptime), pihole has the correct records (`dns/hubble.orion.norseamerican.com → 10.50.0.231` pushed by ExternalDNS on day 1), and `10.50.0.232/32` is correctly advertised from orion-w-02.
- **Fix**: Add a CoreDNS stub zone that forwards `orion.norseamerican.com` queries directly to pihole (`10.50.0.232`), bypassing public DNS for the internal domain. CoreDNS's `reload` plugin picks up ConfigMap changes automatically — no pod restart needed.

## Files

- `kubernetes/infrastructure/coredns/coredns-patch.yaml` — the `kube-system/coredns` ConfigMap with the existing Corefile content plus the stub zone stanza
- `kubernetes/infrastructure/coredns/kustomization.yaml` — Kustomize wrapper
- `kubernetes/clusters/orion/coredns.yaml` — Flux Kustomization; `prune: false` so Flux never deletes the system ConfigMap; `dependsOn: cluster-settings` for `${domain}` / `${externalDnsIp}` substitution

## Test plan

After merge and Flux reconciliation (watch with `flux get ks coredns`):

- [ ] Verify Flux applied the ConfigMap: `kubectl -n kube-system get cm coredns -o jsonpath='{.data.Corefile}'` — should contain the `orion.norseamerican.com:53` block
- [ ] Test in-cluster resolution via CoreDNS: `kubectl run dns-test --image=busybox:1.28 --restart=Never --rm -it -- nslookup dns.orion.norseamerican.com` — should return `10.50.0.231` (not Cloudflare IPs)
- [ ] Test that public DNS still works: `kubectl run dns-test2 --image=busybox:1.28 --restart=Never --rm -it -- nslookup google.com` — should still resolve correctly

## Remaining gaps (not in this PR)

1. **Talos node nameservers** — nodes themselves still use `1.1.1.1`/`8.8.8.8` directly. Update `clusters/orion/patches/cluster/10-network-common.yaml` to add `10.50.0.232` as first nameserver (requires a Talos machine config apply to each node).
2. **Cross-VLAN clients** — UniFi per-network DHCP DNS must be set to `10.50.0.232` (manual step in UniFi UI, no GitOps surface).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated deployment and reconciliation of CoreDNS configuration.
  * Configured cluster DNS resolution, health checks, metrics, caching, and query forwarding.
  * Added forwarding support for domain-specific DNS queries through the configured external DNS endpoint.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->