### PR TITLE
feat(gateway): HTTP→HTTPS redirect for *.orion.norseamerican.com

### DIFF
--- a/kubernetes/infrastructure/gateway/http-redirect.yaml
+++ b/kubernetes/infrastructure/gateway/http-redirect.yaml
@@ -1,0 +1,18 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: http-to-https-redirect
+  namespace: gateway
+spec:
+  parentRefs:
+    - name: orion
+      namespace: gateway
+      sectionName: http
+  hostnames:
+    - "*.${domain}"
+  rules:
+    - filters:
+        - type: RequestRedirect
+          requestRedirect:
+            scheme: https
+            statusCode: 301

--- a/kubernetes/infrastructure/gateway/kustomization.yaml
+++ b/kubernetes/infrastructure/gateway/kustomization.yaml
@@ -5,4 +5,5 @@ resources:
   - certificate.yaml
   - gateway.yaml
   - hubble-httproute.yaml
+  - http-redirect.yaml
   - reference-grant.yaml


### PR DESCRIPTION
## Summary

- Navigating to `http://dns.orion.norseamerican.com` (or any `http://` subdomain) returned 404 because the gateway's HTTP listener had zero attached routes.
- Added a wildcard `RequestRedirect` HTTPRoute on the HTTP listener that sends all `*.orion.norseamerican.com` on port 80 to HTTPS with a 301. Covers pihole and every future app route without needing per-app HTTP routes.

## Test plan

After merge and Flux reconciliation:

- [ ] `kubectl -n gateway get httproute http-to-https-redirect` — should exist and show `Accepted`
- [ ] From a VLAN 20 machine: `curl -v http://dns.orion.norseamerican.com/` → expect `301 → https://dns.orion.norseamerican.com/`
- [ ] Browser: navigate to `http://dns.orion.norseamerican.com` → should redirect to pihole login page (after also renewing DHCP lease so pihole is used as DNS)

## Note on the DNS side

The immediate reason VLAN 20 clients see the Cloudflare page:

| DNS server used | Result for `dns.orion.norseamerican.com` |
|---|---|
| `10.20.0.1` (UDM built-in, old leases) | Cloudflare CDN IPs — wrong |
| `10.50.0.232` (pihole, new leases) | `10.50.0.231` — correct |

VLAN 20 DHCP is already configured to hand out pihole. Clients that got leases before pihole was configured need to **renew their DHCP lease** (`ipconfig /renew` on Windows, disconnect/reconnect on mobile) to start using it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic redirection from HTTP to HTTPS for gateway-hosted domains.
  * HTTP requests now receive a permanent (301) redirect to the secure HTTPS scheme.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->