### PR TITLE
fix(pihole): change dns service to externalTrafficPolicy=Cluster

### DIFF
--- a/kubernetes/apps/pihole2/overlays/orion/loadbalancer.yaml
+++ b/kubernetes/apps/pihole2/overlays/orion/loadbalancer.yaml
@@ -8,7 +8,7 @@ metadata:
     io.cilium/lb-ipam-ips: "10.50.0.232"
 spec:
   type: LoadBalancer
-  externalTrafficPolicy: Local
+  externalTrafficPolicy: Cluster
   selector:
     app: pihole
   ports:


### PR DESCRIPTION
## Summary

- The Cilium L2 announcement lease for `10.50.0.232` (pihole DNS) is held by `orion-cp-02`, but the pihole pod runs on `orion-w-02`
- With `externalTrafficPolicy: Local`, `orion-cp-02` has no local endpoint and silently drops all inbound DNS traffic — this is why VLAN 20 clients get `dns_probe_finish_bad_config` for all domains after renewing their DHCP lease to use pihole
- Changing to `externalTrafficPolicy: Cluster` allows any node (including the L2 lease holder) to proxy DNS packets to the pihole pod on `orion-w-02`
- Source IP preservation is not needed for DNS; pihole does not have per-client group assignments configured

## Root cause details

```
# L2 lease: orion-cp-02 answers ARP for 10.50.0.232 on VLAN 50
cilium-l2announce-pihole-dns    orion-cp-02    30d

# But pihole pod only runs on orion-w-02
NAME                             NODE         IP
pihole-deploy-787b6bd5f4-v7cvr   orion-w-02   10.241.3.182
```

The lease has been held by `orion-cp-02` for 30 days (likely established at initial deploy before Cilium's eTP=Local L2 election enforcement took effect). Traffic from UDM → `orion-cp-02` → no local endpoint → DROP.

## Test plan

- [ ] After merge, wait for Flux to reconcile the `pihole` Kustomization (~1 hour interval, or `flux reconcile ks pihole`)
- [ ] Renew DHCP on a VLAN 20 device and confirm DNS resolution works
- [ ] Verify pihole query log shows queries from 10.20.x.x clients

🤖 Generated with [Claude Code](https://claude.com/claude-code)