### PR TITLE
feat(rbac): add read-only Kubernetes user

### DIFF
--- a/kubernetes/clusters/orion/rbac.yaml
+++ b/kubernetes/clusters/orion/rbac.yaml
@@ -1,0 +1,19 @@
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: rbac
+  namespace: flux-system
+spec:
+  interval: 1h
+  retryInterval: 1m
+  timeout: 3m
+  prune: true
+  wait: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+  path: ./kubernetes/infrastructure/rbac
+  decryption:
+    provider: sops
+    secretRef:
+      name: sops-age

--- a/kubernetes/infrastructure/rbac/kustomization.yaml
+++ b/kubernetes/infrastructure/rbac/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - readonly.yaml
+  - readonly-token.sops.yaml

--- a/kubernetes/infrastructure/rbac/readonly-token.sops.yaml
+++ b/kubernetes/infrastructure/rbac/readonly-token.sops.yaml
@@ -1,0 +1,23 @@
+apiVersion: v1
+kind: Secret
+metadata:
+    name: readonly-token
+    namespace: kube-system
+    annotations:
+        kubernetes.io/service-account.name: readonly
+type: kubernetes.io/service-account-token
+sops:
+    age:
+        - enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBvTUxMamNHc0doR21Tb0U5
+            YU1LV3Q5UXBRMjN0Zk1MT29GTDhpd2NvdUZvCjhBTHoxM2t4MTUwc21tUXZTamJ2
+            VHRoay9CMXdYcE11ZkJhSzFjWHZ2SjAKLS0tIGhDcGlNelUyejZwcWU5eUhnZG5v
+            T296Z0NqS2k2TWlDbEQ5cm82VmxqZG8KkTtb98qjkm2JPHTPHYpI0i8ZzDpHMwHz
+            wpihPrpx9gXp5R3aGKrv55zE0S0pRB6NBB4jhoS1vIS9RHZnU1pZcQ==
+            -----END AGE ENCRYPTED FILE-----
+          recipient: age13tszh09s5hr9hzjdy8enq7uncz9p2z09hsvky2dn25vudr4cx37s6k5n9z
+    encrypted_regex: ^(data|stringData)$
+    lastmodified: "2026-07-18T19:39:49Z"
+    mac: ENC[AES256_GCM,data:C3xq8l95s85xWXq7+hir9gWXCr0YMa4QUHdBirLF98MZTtGo+R4KFMjSs7REikJtwf+wkGGlO9z1Komr68YTok15NJ1Uo8/MiBjl51TxowMpJ3i2Th+SXlU27K867bBCBjD+S+Q/7tfZiNQFoPRFcl2Gv2zXxHSCDKTfSViy1Ys=,iv:9P7W9j5V3khnkG8GIdHx42lx0xF0TOnnzWYMUrDBFlg=,tag:aNTCStf9eCWvhlXSyBdzRg==,type:str]
+    version: 3.13.0

--- a/kubernetes/infrastructure/rbac/readonly.yaml
+++ b/kubernetes/infrastructure/rbac/readonly.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: readonly
+  namespace: kube-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: readonly-view
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: view
+subjects:
+  - kind: ServiceAccount
+    name: readonly
+    namespace: kube-system


### PR DESCRIPTION
## Summary

- Adds a `readonly` ServiceAccount in `kube-system` bound to the built-in `view` ClusterRole (cluster-wide read access, no Secrets)
- Adds a `readonly-token` Secret (type `kubernetes.io/service-account-token`) so the SA gets a non-expiring token; Secret is SOPS-wrapped to satisfy the unencrypted-secrets pre-commit hook (Kubernetes populates the token field — nothing sensitive is in the YAML spec)
- Adds a Flux `Kustomization` at `kubernetes/clusters/orion/rbac.yaml` with SOPS decryption enabled

## After merge — build the kubeconfig

```bash
# Wait for Flux to reconcile (or: flux reconcile ks rbac)
TOKEN=$(kubectl -n kube-system get secret readonly-token -o jsonpath='{.data.token}' | base64 -d)

kubectl config set-cluster orion-readonly \
  --server=https://10.50.0.10:6443 \
  --certificate-authority=<path-to-cluster-ca.crt>

kubectl config set-credentials readonly \
  --token="$TOKEN"

kubectl config set-context orion-readonly \
  --cluster=orion-readonly \
  --user=readonly

kubectl config use-context orion-readonly
```

Or get the CA cert from the existing kubeconfig:
```bash
kubectl config view --raw -o jsonpath='{.clusters[?(@.name=="orion")].cluster.certificate-authority-data}' | base64 -d > /tmp/orion-ca.crt
```

## Test plan

- [ ] Flux reconciles `rbac` Kustomization without errors
- [ ] `kubectl -n kube-system get sa readonly` exists
- [ ] `kubectl -n kube-system get secret readonly-token` has a non-empty `token` field
- [ ] kubeconfig built from the token can list pods (`kubectl get pods -A`)
- [ ] kubeconfig cannot list secrets (`kubectl get secrets -A` → Forbidden)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a read-only Kubernetes access account with permissions limited to viewing cluster resources.
  * Added a securely managed access token for the read-only account.
  * Enabled automated deployment and reconciliation of the access configuration.
  * Configured encrypted secret handling to protect sensitive credential data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->