### PR TITLE
fix(cilium): correct L2 announcement interface regex to ethSel0.50

### DIFF
--- a/kubernetes/infrastructure/cilium/policies/l2-policy.yaml
+++ b/kubernetes/infrastructure/cilium/policies/l2-policy.yaml
@@ -6,4 +6,4 @@ spec:
   externalIPs: true
   loadBalancerIPs: true
   interfaces:
-    - ^enp[12]s0\.50$
+    - ^ethSel0\.50$


### PR DESCRIPTION
## Summary

The `CiliumL2AnnouncementPolicy` interface regex `^enp[12]s0\.50$` never matched any interface on any node. Talos names VLAN sub-interfaces as `ethSel0.<vlanId>` when the parent NIC is selected via `deviceSelector` (by hardware address), not as `enp2s0.50` / `enp1s0.50`.

Result: L2 announcement leases were being elected (the `cilium-l2announce-*` Lease objects existed in the `cilium` namespace), but Cilium never sent any ARP packets because no interface matched the policy. Any device on VLAN 50 trying to ARP for a LB IP (`10.50.0.230–232`) got no response.

**Confirmed via `talosctl get addresses` on all nodes:**
```
enp2s0/10.50.0.11/24       ← physical NIC (CP nodes)
ethSel0.50/10.50.0.11/24   ← actual VLAN 50 sub-interface (all nodes)
ethSel0.10/10.10.0.11/24   ← VLAN 10 sub-interface
```

Changed regex to `^ethSel0\.50$` which matches the actual interface on all five nodes.

## Impact

- BGP-routed cross-VLAN access to LB IPs was unaffected (BGP uses TCP sessions, not interface names)
- Same-subnet (VLAN 50) devices and the UDM's connected-route ARP path for LB IPs were broken
- After this fix, L2 ARP for `10.50.0.230`, `10.50.0.231`, `10.50.0.232` will work on VLAN 50

## Test plan

- [ ] After Flux reconciles, check that L2 lease holders start sending gratuitous ARPs: `kubectl -n cilium get lease | grep l2announce`
- [ ] ARP test from a VLAN 50 host: `arping -I <iface> 10.50.0.232` should get a reply from the lease-holding node's MAC
- [ ] Ping `10.50.0.232` from a VLAN 50 device (separate from the cluster nodes) should succeed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated network interface matching for L2 announcements to support the current `ethSel0.50` interface name.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->