### PR TITLE
fix(cilium): use physical NIC for L2 announcements, not tagged VLAN sub-interface

### DIFF
--- a/kubernetes/infrastructure/cilium/policies/l2-policy.yaml
+++ b/kubernetes/infrastructure/cilium/policies/l2-policy.yaml
@@ -6,4 +6,4 @@ spec:
   externalIPs: true
   loadBalancerIPs: true
   interfaces:
-    - ^ethSel0\.50$
+    - ^enp[12]s0$


### PR DESCRIPTION
## Summary

PR #57 changed the L2 announcement interface regex to `^ethSel0\.50$`, but that's still wrong. Root cause analysis:

- VLAN 50 is the **native (untagged)** VLAN on the switch trunk ports connecting cluster nodes
- Confirmed via `ip neigh show 10.50.0.1` on nodes: the UDM gateway is reachable via `enp1s0` / `enp2s0` (the physical NIC), not via `ethSel0.50`
- Gratuitous ARPs sent on `ethSel0.50` (tagged VLAN 50) are dropped at the switch — the switch treats them as double-tagged frames on the native VLAN

The correct interface for L2 announcements is the physical NIC (`enp1s0` on workers, `enp2s0` on CP nodes), which sends untagged frames that the switch correctly places in VLAN 50.

## Diagnosis chain

1. VLAN 20 ping to `10.50.0.232` → "destination host unreachable" from UDM (`10.20.0.1`)
2. VLAN 20 ping to node IP `10.50.0.11` → works (firewall not the issue)
3. L2 lease re-acquired, gratuitous ARP sent on `ethSel0.50` → still unreachable
4. `ip neigh show 10.50.0.1` on node → ARP entry is on `enp1s0`, not `ethSel0.50`
5. Conclusion: untagged traffic on the physical NIC is the correct path for VLAN 50

## Test plan

- [ ] After Flux reconciles, delete L2 leases to force re-election and fresh gratuitous ARPs: `kubectl -n cilium delete lease -l app.kubernetes.io/part-of=cilium` (or delete individually)
- [ ] Ping `10.50.0.232` from VLAN 20 — should now respond
- [ ] DNS should resolve on VLAN 20 devices

🤖 Generated with [Claude Code](https://claude.com/claude-code)