### PR TITLE
fix(docs): add inbound route-map to UDM FRR BGP config

### DIFF
--- a/clusters/orion/docs/unifi-bgp-frr.md
+++ b/clusters/orion/docs/unifi-bgp-frr.md
@@ -5,45 +5,77 @@ This is the FRR config to upload in **UniFi → Settings → Routing → BGP**.
 Cluster ASN: `65001`
 UDM ASN: `65000`
 Peers: all five orion nodes on VLAN 50 (`10.50.0.11–13` control plane, `10.50.0.21–22` workers)
+LB pool: `10.50.0.230–239` (CiliumLoadBalancerIPPool `pool`, fits within `10.50.0.224/28`)
+
+## FRR config
+
+FRR enforces RFC 8212 (`bgp ebgp-requires-policy`) by default — eBGP routes from
+a neighbor with no inbound policy are silently rejected (sessions still establish,
+but `PfxRcd` shows `(Policy)`). The config below adds a prefix-list scoped to the
+LB pool and a route-map applied inbound on all neighbors.
 
 ```
+ip prefix-list CILIUM-LB seq 5 permit 10.50.0.224/28 le 32
+
+route-map CILIUM-IN permit 10
+ match ip address prefix-list CILIUM-LB
+
 router bgp 65000
-  bgp router-id 10.50.0.1
-  neighbor 10.50.0.11 remote-as 65001
-  neighbor 10.50.0.12 remote-as 65001
-  neighbor 10.50.0.13 remote-as 65001
-  neighbor 10.50.0.21 remote-as 65001
-  neighbor 10.50.0.22 remote-as 65001
-  address-family ipv4 unicast
-    neighbor 10.50.0.11 activate
-    neighbor 10.50.0.12 activate
-    neighbor 10.50.0.13 activate
-    neighbor 10.50.0.21 activate
-    neighbor 10.50.0.22 activate
-  exit-address-family
+ bgp router-id 10.50.0.1
+ neighbor 10.50.0.11 remote-as 65001
+ neighbor 10.50.0.12 remote-as 65001
+ neighbor 10.50.0.13 remote-as 65001
+ neighbor 10.50.0.21 remote-as 65001
+ neighbor 10.50.0.22 remote-as 65001
+ address-family ipv4 unicast
+  neighbor 10.50.0.11 activate
+  neighbor 10.50.0.11 route-map CILIUM-IN in
+  neighbor 10.50.0.12 activate
+  neighbor 10.50.0.12 route-map CILIUM-IN in
+  neighbor 10.50.0.13 activate
+  neighbor 10.50.0.13 route-map CILIUM-IN in
+  neighbor 10.50.0.21 activate
+  neighbor 10.50.0.21 route-map CILIUM-IN in
+  neighbor 10.50.0.22 activate
+  neighbor 10.50.0.22 route-map CILIUM-IN in
+ exit-address-family
 ```
 
 ## After applying
 
-Verify sessions are up from the UDM:
+Verify sessions are up and routes are being received (requires SSH access or
+UniFi console):
 
 ```
 vtysh -c "show bgp summary"
 ```
 
-All five neighbors should show `Establ` state and a non-zero `PfxRcd` (received
-prefixes) — expect at least two: `10.50.0.231/32` (gateway) and `10.50.0.232/32`
-(pihole DNS).
+All five neighbors should show `Establ` state and `PfxRcd` of **3** (not
+`(Policy)`): `10.50.0.230/32` (cilium-ingress), `10.50.0.231/32` (gateway),
+`10.50.0.232/32` (pihole DNS).
 
 ```
 vtysh -c "show ip route bgp"
 ```
 
-Both VIPs should appear as BGP routes.
+All three VIPs should appear as BGP routes with next-hops pointing to the
+advertising node IPs.
 
 ## Verify from cluster (read-only)
 
+```bash
+KUBECONFIG=~/.kube/orion.yaml kubectl -n cilium exec ds/cilium -c cilium-agent -- \
+  cilium bgp peers
+
+KUBECONFIG=~/.kube/orion.yaml kubectl -n cilium exec ds/cilium -c cilium-agent -- \
+  cilium bgp routes advertised ipv4 unicast
 ```
-kubectl --context admin@orion -n kube-system exec ds/cilium -- cilium bgp peers
-kubectl --context admin@orion -n kube-system exec ds/cilium -- cilium bgp routes advertised ipv4 unicast
-```
+
+## Notes
+
+- Once BGP routes are installed, the UDM will prefer the /32 BGP routes (longest
+  prefix match) over the connected /24, making L2 ARP announcements a fallback
+  rather than the only path. This removes the dependency on L2 for cross-VLAN
+  routing to LB VIPs.
+- The FRR config is uploaded via the UniFi UI and is not git-managed. Keep this
+  doc in sync with any changes made there.


### PR DESCRIPTION
## Summary

FRR (used by the UDM) enforces RFC 8212 (`bgp ebgp-requires-policy`) by default. Without an inbound route-map on each eBGP neighbor, routes are silently rejected — sessions still show as `Establ` but `PfxRcd` shows `(Policy)` and nothing is installed in the routing table. This is why the UDM has never had BGP /32 routes for the LB VIPs despite 757h of established sessions.

Updates `unifi-bgp-frr.md` with:
- A `prefix-list CILIUM-LB` scoped to the LB pool (`10.50.0.224/28 le 32`)
- A `route-map CILIUM-IN permit 10` referencing that prefix-list
- `route-map CILIUM-IN in` applied to all five neighbors in the address-family block
- Corrected advertised prefix count (3, not 2: cilium-ingress `.230`, gateway `.231`, pihole `.232`)
- Updated `kubectl` verification commands (correct namespace `cilium`, container `-c cilium-agent`)

## Action required (manual — UniFi UI)

1. Copy the new FRR config block from the doc
2. **UniFi → Settings → Routing → BGP** → paste and save
3. Verify on UDM: `vtysh -c "show bgp summary"` → all 5 neighbors should show `PfxRcd: 3`
4. Verify: `vtysh -c "show ip route bgp"` → three /32 routes present

## Impact

Once BGP routes are installed, the UDM uses longest-prefix-match to prefer the /32 BGP routes over the connected /24 for LB VIPs. L2 announcements become a fallback rather than the only path, making cross-VLAN access to cluster services resilient to L2 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated UniFi UDM BGP/FRR configuration guidance with explicit inbound route filtering.
  * Added verification steps for three expected Cilium load balancer VIP routes.
  * Updated cluster verification commands and clarified routing behavior.
  * Added a reminder to keep the uploaded FRR configuration synchronized with the documented settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->