### PR TITLE
feat(external-dns): add ingress source for pihole DNS records

### DIFF
--- a/kubernetes/infrastructure/external-dns/release.yaml
+++ b/kubernetes/infrastructure/external-dns/release.yaml
@@ -25,6 +25,7 @@ spec:
       name: pihole
     sources:
       - gateway-httproute
+      - ingress
     domainFilters:
       - ${domain}
     registry: noop


### PR DESCRIPTION
## Summary

- ExternalDNS was only configured with `gateway-httproute` as a source
- vkms monitoring services (Grafana, VMAgent, VMAlert, AlertManager, VMSingle) are exposed via `kind: Ingress` at `10.50.0.230`, so no pihole DNS records existed for them
- Clients resolving these hostnames via pihole got the dnsmasq wildcard (`*.orion.norseamerican.com → 10.50.0.231`), hit the Gateway, and found no matching HTTPRoute

Adds `ingress` to the ExternalDNS sources list. ExternalDNS will now read `status.loadBalancer.ingress[0].ip` from each Ingress and create the corresponding pihole custom DNS records automatically — same as it already does for HTTPRoutes.

## Test plan

- [ ] Flux reconciles external-dns HelmRelease
- [ ] ExternalDNS logs show Ingress records being synced: `kubectl -n external-dns logs deploy/external-dns | grep -i ingress`
- [ ] `dig @10.50.0.232 grafana.orion.norseamerican.com +short` returns `10.50.0.230`
- [ ] `https://grafana.orion.norseamerican.com` loads from a VLAN 20 device

🤖 Generated with [Claude Code](https://claude.com/claude-code)