### PR TITLE
feat(rook-ceph): deploy Rook Ceph as default block storage

### DIFF
--- a/kubernetes/clusters/orion/rook-ceph-cluster.yaml
+++ b/kubernetes/clusters/orion/rook-ceph-cluster.yaml
@@ -1,0 +1,21 @@
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: rook-ceph-cluster
+  namespace: flux-system
+spec:
+  interval: 30m
+  retryInterval: 1m
+  timeout: 15m
+  prune: true
+  wait: true
+  dependsOn:
+    - name: rook-ceph-operator
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+  path: ./kubernetes/infrastructure/rook-ceph-cluster
+  decryption:
+    provider: sops
+    secretRef:
+      name: sops-age

--- a/kubernetes/clusters/orion/rook-ceph-operator.yaml
+++ b/kubernetes/clusters/orion/rook-ceph-operator.yaml
@@ -1,0 +1,21 @@
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: rook-ceph-operator
+  namespace: flux-system
+spec:
+  interval: 30m
+  retryInterval: 1m
+  timeout: 15m
+  prune: true
+  wait: true
+  dependsOn:
+    - name: cluster-settings
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+  path: ./kubernetes/infrastructure/rook-ceph-operator
+  decryption:
+    provider: sops
+    secretRef:
+      name: sops-age

--- a/kubernetes/infrastructure/rook-ceph-cluster/blockpool.yaml
+++ b/kubernetes/infrastructure/rook-ceph-cluster/blockpool.yaml
@@ -1,0 +1,30 @@
+apiVersion: ceph.rook.io/v1
+kind: CephBlockPool
+metadata:
+  name: replicapool
+  namespace: rook-ceph
+spec:
+  failureDomain: host
+  replicated:
+    size: 3
+---
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: rook-ceph-block
+  annotations:
+    storageclass.kubernetes.io/is-default-class: "true"
+provisioner: rook-ceph.rbd.csi.ceph.com
+parameters:
+  clusterID: rook-ceph
+  pool: replicapool
+  imageFormat: "2"
+  imageFeatures: layering
+  csi.storage.k8s.io/provisioner-secret-name: rook-csi-rbd-provisioner
+  csi.storage.k8s.io/provisioner-secret-namespace: rook-ceph
+  csi.storage.k8s.io/controller-expand-secret-name: rook-csi-rbd-provisioner
+  csi.storage.k8s.io/controller-expand-secret-namespace: rook-ceph
+  csi.storage.k8s.io/node-stage-secret-name: rook-csi-rbd-node
+  csi.storage.k8s.io/node-stage-secret-namespace: rook-ceph
+reclaimPolicy: Delete
+allowVolumeExpansion: true

--- a/kubernetes/infrastructure/rook-ceph-cluster/cluster.yaml
+++ b/kubernetes/infrastructure/rook-ceph-cluster/cluster.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: rook-ceph
 spec:
   cephVersion:
-    image: quay.io/ceph/ceph:v21.1.0
+    image: quay.io/ceph/ceph:v20.2.2
     allowUnsupported: false
   dataDirHostPath: /var/lib/rook
   mon:

--- a/kubernetes/infrastructure/rook-ceph-cluster/cluster.yaml
+++ b/kubernetes/infrastructure/rook-ceph-cluster/cluster.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: rook-ceph
 spec:
   cephVersion:
-    image: quay.io/ceph/ceph:v19.2.2
+    image: quay.io/ceph/ceph:v21.1.0
     allowUnsupported: false
   dataDirHostPath: /var/lib/rook
   mon:

--- a/kubernetes/infrastructure/rook-ceph-cluster/cluster.yaml
+++ b/kubernetes/infrastructure/rook-ceph-cluster/cluster.yaml
@@ -1,0 +1,57 @@
+apiVersion: ceph.rook.io/v1
+kind: CephCluster
+metadata:
+  name: rook-ceph
+  namespace: rook-ceph
+spec:
+  cephVersion:
+    image: quay.io/ceph/ceph:v19.2.2
+    allowUnsupported: false
+  dataDirHostPath: /var/lib/rook
+  mon:
+    count: 3
+    allowMultiplePerNode: false
+  mgr:
+    count: 1
+    allowMultiplePerNode: false
+    modules:
+      - name: pg_autoscaler
+        enabled: true
+  dashboard:
+    enabled: true
+    ssl: true
+  monitoring:
+    enabled: false
+  network:
+    connections:
+      encryption:
+        enabled: false
+      compression:
+        enabled: false
+  crashCollector:
+    disable: false
+  cleanupPolicy:
+    confirmation: ""
+  removeOSDsIfOutAndSafeToRemove: false
+  storage:
+    useAllNodes: false
+    useAllDevices: false
+    nodes:
+      - name: orion-cp-01
+        devices:
+          - name: /dev/disk/by-id/ata-Samsung_SSD_870_EVO_500GB_S6PXNS0W525343F
+      - name: orion-cp-02
+        devices:
+          - name: /dev/disk/by-id/ata-Samsung_SSD_870_QVO_2TB_S6R4NJ0W405219J
+      - name: orion-cp-03
+        devices:
+          - name: /dev/disk/by-id/ata-Samsung_SSD_870_EVO_500GB_S6PXNL0W600075W
+      - name: orion-w-01
+        devices:
+          - name: /dev/disk/by-id/nvme-WD_BLACK_SN7100_2TB_251742800063
+      - name: orion-w-02
+        devices:
+          - name: /dev/disk/by-id/nvme-NX-2TB_2280_9I50508002207
+  disruptionManagement:
+    managePodBudgets: true
+    osdMaintenanceTimeout: 30

--- a/kubernetes/infrastructure/rook-ceph-cluster/kustomization.yaml
+++ b/kubernetes/infrastructure/rook-ceph-cluster/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - cluster.yaml
+  - blockpool.yaml

--- a/kubernetes/infrastructure/rook-ceph-operator/kustomization.yaml
+++ b/kubernetes/infrastructure/rook-ceph-operator/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - namespace.yaml
+  - repo.yaml
+  - release.yaml

--- a/kubernetes/infrastructure/rook-ceph-operator/namespace.yaml
+++ b/kubernetes/infrastructure/rook-ceph-operator/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: rook-ceph

--- a/kubernetes/infrastructure/rook-ceph-operator/release.yaml
+++ b/kubernetes/infrastructure/rook-ceph-operator/release.yaml
@@ -8,7 +8,7 @@ spec:
   chart:
     spec:
       chart: rook-ceph
-      version: 1.16.0
+      version: 1.20.2
       sourceRef:
         kind: HelmRepository
         name: rook-release

--- a/kubernetes/infrastructure/rook-ceph-operator/release.yaml
+++ b/kubernetes/infrastructure/rook-ceph-operator/release.yaml
@@ -1,0 +1,27 @@
+apiVersion: helm.toolkit.fluxcd.io/v2beta1
+kind: HelmRelease
+metadata:
+  name: rook-ceph-operator
+  namespace: rook-ceph
+spec:
+  interval: 30m
+  chart:
+    spec:
+      chart: rook-ceph
+      version: 1.16.0
+      sourceRef:
+        kind: HelmRepository
+        name: rook-release
+        namespace: flux-system
+      interval: 12h
+  install:
+    crds: CreateReplace
+    remediation:
+      retries: 3
+  upgrade:
+    crds: CreateReplace
+    remediation:
+      retries: 3
+  values:
+    crds:
+      enabled: true

--- a/kubernetes/infrastructure/rook-ceph-operator/repo.yaml
+++ b/kubernetes/infrastructure/rook-ceph-operator/repo.yaml
@@ -1,0 +1,8 @@
+apiVersion: source.toolkit.fluxcd.io/v1beta2
+kind: HelmRepository
+metadata:
+  name: rook-release
+  namespace: flux-system
+spec:
+  interval: 1h
+  url: https://charts.rook.io/release


### PR DESCRIPTION
## Summary
- Deploys Rook Ceph operator (v1.16.0) and CephCluster via two Flux Kustomizations
- `rook-ceph-operator` installs CRDs + operator first; `rook-ceph-cluster` depends on it
- CephCluster configures one OSD per node using explicit `by-id` disk paths
- 3-replica `CephBlockPool` with `failureDomain: host` for proper redundancy
- `rook-ceph-block` StorageClass set as cluster default, replacing Longhorn

## OSD disk inventory
| Node | Disk | Capacity |
|---|---|---|
| orion-cp-01 | `ata-Samsung_SSD_870_EVO_500GB_S6PXNS0W525343F` | 500 GB |
| orion-cp-02 | `ata-Samsung_SSD_870_QVO_2TB_S6R4NJ0W405219J` | 2 TB |
| orion-cp-03 | `ata-Samsung_SSD_870_EVO_500GB_S6PXNL0W600075W` | 500 GB |
| orion-w-01 | `nvme-WD_BLACK_SN7100_2TB_251742800063` | 2 TB |
| orion-w-02 | `nvme-NX-2TB_2280_9I50508002207` | 2 TB |

## Merge order
Merge after #63 (talos upgrade) and #64 (rook prep / rbd kernel module).

## Test plan
- [ ] Verify operator pod running: `kubectl -n rook-ceph get pods`
- [ ] Verify cluster HEALTH_OK: `kubectl -n rook-ceph get cephcluster`
- [ ] Verify 5 OSDs up: `kubectl -n rook-ceph exec -it deploy/rook-ceph-tools -- ceph osd status`
- [ ] Verify default StorageClass: `kubectl get sc`
- [ ] Create a test PVC and confirm it binds

> **Note:** Verify chart version `1.16.0` exists at `https://charts.rook.io/release` and Ceph image `quay.io/ceph/ceph:v19.2.2` is current before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)