### PR TITLE
fix(rook-ceph): correct Flux API versions and test script shell

### DIFF
--- a/.taskfiles/LocalTest/Tasks.yml
+++ b/.taskfiles/LocalTest/Tasks.yml
@@ -15,7 +15,7 @@ tasks:
     vars:
       CLUSTER: '{{.CLUSTER | default "orion"}}'
     cmds:
-      - sh scripts/flux-build.sh {{.CLUSTER}}
+      - bash scripts/flux-build.sh {{.CLUSTER}}
 
   build-all:
     desc: "Offline-render Kustomizations for both clusters"

--- a/kubernetes/infrastructure/rook-ceph-operator/release.yaml
+++ b/kubernetes/infrastructure/rook-ceph-operator/release.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
   name: rook-ceph-operator

--- a/kubernetes/infrastructure/rook-ceph-operator/repo.yaml
+++ b/kubernetes/infrastructure/rook-ceph-operator/repo.yaml
@@ -1,4 +1,4 @@
-apiVersion: source.toolkit.fluxcd.io/v1beta2
+apiVersion: source.toolkit.fluxcd.io/v1
 kind: HelmRepository
 metadata:
   name: rook-release


### PR DESCRIPTION
## Summary
Fixes missed from #65 — merged before these commits landed on the branch.

- `repo.yaml`: `source.toolkit.fluxcd.io/v1beta2` → `v1` (v1beta2 not available on this cluster)
- `release.yaml`: `helm.toolkit.fluxcd.io/v2beta1` → `v2`
- `LocalTest/Tasks.yml`: `sh` → `bash` so `task test:build` works (script uses process substitution)

## Test plan
- [x] `task test:build` — 14/14 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Updated storage infrastructure deployment definitions to use current Flux resource APIs, improving compatibility with newer platform tooling.
  - Improved local build task execution by invoking the build script with the appropriate shell.

- **Chores**
  - Preserved existing cluster configuration, chart settings, repository references, and deployment behavior while applying these compatibility updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->