### PR TITLE
fix(ci): make flux-build.sh actually validate orion

### DIFF
--- a/.taskfiles/LocalTest/Tasks.yml
+++ b/.taskfiles/LocalTest/Tasks.yml
@@ -96,13 +96,11 @@ tasks:
           --tag=latest \
           --insecure \
           --interval=1m
-      # 2. Apply cluster-settings ConfigMap so substituteFrom can resolve
-      - |
-        case "{{.CLUSTER}}" in
-          na)    kubectl apply -f kubernetes/clusters/na/settings/cluster-settings.yaml ;;
-          orion) kubectl apply -f kubernetes/clusters/orion/cluster-settings.yaml ;;
-          *)     kubectl apply -f kubernetes/clusters/{{.CLUSTER}}/cluster-settings.yaml ;;
-        esac
+      # 2. Apply cluster-settings ConfigMap so substituteFrom can resolve.
+      #    NOTE: this is kubernetes/clusters/<cluster>/settings/cluster-settings.yaml
+      #    (the ConfigMap) — not kubernetes/clusters/<cluster>/cluster-settings.yaml
+      #    (that's the Flux Kustomization CR that points at the settings/ dir).
+      - kubectl apply -f kubernetes/clusters/{{.CLUSTER}}/settings/cluster-settings.yaml
       # 3. Apply all Flux Kustomization YAMLs for the cluster (skip bootstrap files)
       - |
         for f in kubernetes/clusters/{{.CLUSTER}}/*.yaml; do

--- a/scripts/flux-build.sh
+++ b/scripts/flux-build.sh
@@ -4,10 +4,11 @@
 # Mirrors Flux's postBuild.substituteFrom behaviour without a live cluster.
 #
 # Usage: scripts/flux-build.sh <cluster>
-#   cluster: orion | na  (default: orion)
+#   cluster: orion  (default: orion)
 #
 # Prerequisites: kustomize, yq, python3
-#                sops (only for na when SOPS_AGE_KEY_FILE is set)
+#                sops (when the cluster has a cluster-secrets.sops.yaml and
+#                SOPS_AGE_KEY_FILE is set)
 
 set -euo pipefail
 
@@ -24,10 +25,7 @@ command -v python3   >/dev/null 2>&1 || { echo "ERROR: python3 not found" >&2; e
 # ── Variable substitution ────────────────────────────────────────────────────
 # Mirrors Flux's postBuild.substituteFrom: replaces ${VAR} in rendered YAML.
 
-case "$CLUSTER" in
-  na)   SETTINGS_FILE="$CLUSTER_DIR/settings/cluster-settings.yaml" ;;
-  *)    SETTINGS_FILE="$CLUSTER_DIR/cluster-settings.yaml" ;;
-esac
+SETTINGS_FILE="$CLUSTER_DIR/settings/cluster-settings.yaml"
 
 [[ -f "$SETTINGS_FILE" ]] || { echo "ERROR: settings file not found: $SETTINGS_FILE" >&2; exit 1; }
 
@@ -37,10 +35,10 @@ while IFS='=' read -r key val; do
   export "$key"="$val"
 done < <(yq eval '.data | to_entries | .[] | .key + "=" + .value' "$SETTINGS_FILE")
 
-# For na: optionally decrypt SOPS secret and export its vars too
-if [[ "$CLUSTER" == "na" ]]; then
-  SECRETS_FILE="$CLUSTER_DIR/settings/cluster-secrets.sops.yaml"
-  if [[ -f "$SECRETS_FILE" && -n "${SOPS_AGE_KEY_FILE:-}" && -f "${SOPS_AGE_KEY_FILE:-}" ]]; then
+# Optionally decrypt the cluster's SOPS secret and export its vars too.
+SECRETS_FILE="$CLUSTER_DIR/settings/cluster-secrets.sops.yaml"
+if [[ -f "$SECRETS_FILE" ]]; then
+  if [[ -n "${SOPS_AGE_KEY_FILE:-}" && -f "${SOPS_AGE_KEY_FILE:-}" ]]; then
     echo "INFO  Decrypting cluster secrets for $CLUSTER"
     DECRYPTED="$(sops -d "$SECRETS_FILE")"
 
@@ -82,9 +80,13 @@ KUSTOMIZE_FLAGS=("--load-restrictor=LoadRestrictionsNone")
 for ks_file in $(find "$CLUSTER_DIR" -maxdepth 3 -name '*.yaml' \
     -not -path '*/flux-system/*' | sort); do
 
-  # Extract name|path for every Flux Kustomization object in this file.
-  # Files can contain multiple YAML documents (e.g. cert-manager + cert-manager-issuers).
-  while IFS='|' read -r name path; do
+  # Extract name|path|substitute for every Flux Kustomization object in this
+  # file. `substitute` is spec.postBuild.substitute (literal key=value pairs
+  # inline on the CR, e.g. appName/subdomain) — distinct from substituteFrom
+  # (the ConfigMap/Secret handled above) and just as required for a faithful
+  # render. Files can contain multiple YAML documents (e.g. cert-manager +
+  # cert-manager-issuers).
+  while IFS='|' read -r name path substitute; do
     [[ -z "$name" || "$name" == "null" ]] && continue
     [[ -z "$path" || "$path" == "null" ]] && continue
     path="${path#./}"   # strip leading ./
@@ -99,10 +101,31 @@ for ks_file in $(find "$CLUSTER_DIR" -maxdepth 3 -name '*.yaml' \
       continue
     }
 
-    if kustomize build "$BUILD_PATH" "${KUSTOMIZE_FLAGS[@]}" \
-        | python3 -c "$ENVSUBST_PY" \
-        > /dev/null 2>&1; then
-      echo "  ✓ $name"
+    # postBuild.substitute literals are scoped to this Kustomization only —
+    # export them for this build, then unset so they don't leak into the next.
+    LITERAL_KEYS=()
+    if [[ -n "$substitute" ]]; then
+      IFS=';' read -ra pairs <<< "$substitute"
+      for pair in "${pairs[@]}"; do
+        [[ -z "$pair" ]] && continue
+        key="${pair%%=*}"
+        val="${pair#*=}"
+        export "$key"="$val"
+        LITERAL_KEYS+=("$key")
+      done
+    fi
+
+    if RENDERED="$(kustomize build "$BUILD_PATH" "${KUSTOMIZE_FLAGS[@]}" | python3 -c "$ENVSUBST_PY")"; then
+      # kustomize build succeeding says nothing about substitution — check
+      # separately for ${VAR} placeholders that never got resolved.
+      UNRESOLVED="$(printf '%s' "$RENDERED" | grep -oE '\$\{[A-Za-z_][A-Za-z0-9_]*(:[^}]*)?\}' | sort -u || true)"
+      if [[ -n "$UNRESOLVED" ]]; then
+        echo "  ✗ $name — unresolved variable(s):"
+        echo "$UNRESOLVED" | sed 's/^/      /'
+        FAILED=$((FAILED + 1))
+      else
+        echo "  ✓ $name"
+      fi
     else
       echo "  ✗ $name — FAILED (re-running to show error):"
       kustomize build "$BUILD_PATH" "${KUSTOMIZE_FLAGS[@]}" \
@@ -111,8 +134,12 @@ for ks_file in $(find "$CLUSTER_DIR" -maxdepth 3 -name '*.yaml' \
       FAILED=$((FAILED + 1))
     fi
 
+    for k in "${LITERAL_KEYS[@]:-}"; do
+      [[ -n "$k" ]] && unset "$k"
+    done
+
   done < <(yq eval \
-    'select(.kind == "Kustomization" and (.apiVersion | test("kustomize.toolkit.fluxcd.io"))) | .metadata.name + "|" + .spec.path' \
+    'select(.kind == "Kustomization" and (.apiVersion | test("kustomize.toolkit.fluxcd.io"))) | .metadata.name + "|" + .spec.path + "|" + ((.spec.postBuild.substitute // {}) | to_entries | map(.key + "=" + .value) | join(";"))' \
     "$ks_file" 2>/dev/null)
 
 done

--- a/scripts/validate.sh
+++ b/scripts/validate.sh
@@ -40,7 +40,7 @@ find . -type f -name '*.yaml' -print0 | while IFS= read -r -d $'\0' file;
     yq e 'true' "$file" > /dev/null
 done
 
-kubeconform_config=("-strict" "-ignore-missing-schemas" "-skip=Secret,ConfigMap" "-kubernetes-version" "1.31.1" "-schema-location" "/tmp/flux-crd-schemas" "-schema-location" "default" "-verbose")
+kubeconform_config=("-strict" "-ignore-missing-schemas" "-skip=Secret,ConfigMap" "-kubernetes-version" "1.33.0" "-schema-location" "/tmp/flux-crd-schemas" "-schema-location" "default" "-verbose")
 
 echo "INFO - Validating clusters"
 find ./kubernetes/clusters -maxdepth 4 -type f -name '*.yaml' -print0 | while IFS= read -r -d $'\0' file;


### PR DESCRIPTION
## Summary

PR 1 of the repo refactor (`~/.claude/plans/we-will-be-refactoring-scalable-heron.md`): fixes CI's orion validation, which was previously a false pass.

## The bug

`scripts/flux-build.sh` picked the settings file with:
```bash
case "$CLUSTER" in
  na)   SETTINGS_FILE="$CLUSTER_DIR/settings/cluster-settings.yaml" ;;
  *)    SETTINGS_FILE="$CLUSTER_DIR/cluster-settings.yaml" ;;
esac
```
For orion this resolves to `kubernetes/clusters/orion/cluster-settings.yaml` — the **Flux `Kustomization` CR**, not the settings ConfigMap (which lives at `orion/settings/cluster-settings.yaml`). `yq '.data'` on the CR returns nothing, so **zero variables were substituted** for orion's render, and CI's `flux-build.sh orion` step passed regardless of what was actually in the manifests. It also only decrypted `cluster-secrets.sops.yaml` `if [[ "$CLUSTER" == "na" ]]`, despite orion having its own.

The same wrong-path bug existed in `.taskfiles/LocalTest/Tasks.yml`'s `kind-reconcile`.

Fixing just the path surfaced a second, deeper gap: the script never checked whether substitution actually *happened* — it only checked `kustomize build`'s exit code, and `${VAR}` placeholders left unresolved don't make that command fail. So even with the right settings file, a missing variable would render silently and still pass.

## Fixes

- `scripts/flux-build.sh` — read `settings/cluster-settings.yaml` for any cluster; decrypt `settings/cluster-secrets.sops.yaml` whenever it exists rather than gating on cluster name.
- Same fix in `.taskfiles/LocalTest/Tasks.yml` `kind-reconcile`.
- The script now scans the rendered, substituted output for leftover `${VAR}` placeholders and fails the build if any remain — this is what actually caught the fix being incomplete (see below).
- That check immediately caught a real gap: `spec.postBuild.substitute` literals inline on a Kustomization CR (e.g. `pihole`'s `appName`/`subdomain`) were never applied — only `substituteFrom` (ConfigMap/Secret) was. Now extracted and exported per-Kustomization, then unset after each build so they don't leak into the next one.
- Bumped kubeconform `-kubernetes-version` 1.31.1 → 1.33.0 to match `talconfig.yaml`'s actual cluster version.

## Verification

```
$ task test:build          # orion — now 14/14 passed, with real substitution (was previously a false pass)
$ task test:build CLUSTER=na   # 19/19, unaffected (na decommission is PR 2)
$ task gen:validate         # yamllint, kubeconform, kube-linter, talhelper — clean
```

Scope: this PR is deliberately narrow (script/task fixes only). `na` decommissioning, dead-code removal, naming conventions, and docs are separate PRs in the plan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Cluster builds now consistently use the appropriate cluster-specific settings.
  * Encrypted secrets and inline configuration substitutions are handled more reliably during builds.
  * Build output is retained for easier inspection, and unresolved configuration placeholders now cause clear failures.
* **Bug Fixes**
  * Improved warnings and error detection when generating deployment configurations.
* **Validation**
  * Kubernetes manifests are now validated against the Kubernetes 1.33 schema set.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->