### PR TITLE
docs: condense over-explanatory comments/READMEs from the refactor

### DIFF
--- a/.taskfiles/LocalTest/Tasks.yml
+++ b/.taskfiles/LocalTest/Tasks.yml
@@ -86,18 +86,11 @@ tasks:
           --tag=latest \
           --insecure \
           --interval=1m
-      # 2. Apply cluster-settings ConfigMap so substituteFrom can resolve.
-      #    NOTE: this is kubernetes/settings/<cluster>/cluster-settings.yaml
-      #    (the ConfigMap, lives outside kubernetes/clusters/<cluster>/ on
-      #    purpose — see cluster-settings.yaml's comment) — not
-      #    kubernetes/clusters/<cluster>/cluster-settings.yaml (that's the
-      #    Flux Kustomization CR that points at it).
+      # 2. Apply the cluster-settings ConfigMap (kubernetes/settings/<cluster>/,
+      #    not the same-named Flux Kustomization CR in clusters/<cluster>/)
+      #    so substituteFrom can resolve.
       - kubectl apply -f kubernetes/settings/{{.CLUSTER}}/cluster-settings.yaml
-      # 3. Apply all Flux Kustomization YAMLs for the cluster (skip
-      #    flux-system/, handled by `flux install` above). This DOES include
-      #    cluster-settings.yaml — that's the real Flux Kustomization CR that
-      #    reconciles kubernetes/settings/<cluster>/ (with sops decryption),
-      #    and everything else's dependsOn: cluster-settings waits on it.
+      # 3. Apply all Flux Kustomization YAMLs (skip flux-system/, handled above)
       - |
         for f in kubernetes/clusters/{{.CLUSTER}}/*.yaml; do
           case "$f" in

--- a/kubernetes/README.md
+++ b/kubernetes/README.md
@@ -9,7 +9,6 @@ kubernetes/
 ├── bootstrap/        # One-time Flux install kustomization (run once per cluster)
 ├── clusters/orion/   # Flux entry point for the orion cluster
 ├── settings/orion/   # cluster-settings ConfigMap + cluster-secrets sops Secret
-│                     #   (deliberately outside clusters/orion/ — see below)
 ├── infrastructure/   # Shared building blocks: CNI, gateway, storage, observability
 ├── apps/             # Workload deployments (some not yet wired into orion — kept
 │                     #   from the decommissioned na cluster pending migration)
@@ -20,18 +19,16 @@ kubernetes/
 
 Each cluster under `clusters/<name>/` contains:
 - `flux-system/` — Flux bootstrap components (`gotk-components.yaml`, `gotk-sync.yaml`)
-- `cluster-settings.yaml` — the Flux Kustomization CR that reconciles `settings/<name>/`
-  (with sops decryption) — not to be confused with `settings/<name>/cluster-settings.yaml`,
-  the actual ConfigMap providing cluster-scoped variables (`${domain}`, `${externalIp}`)
-- One Kustomization per infrastructure component and app, each pointing at the relevant path in `infrastructure/` or `apps/` with `substituteFrom: cluster-settings`
+- `cluster-settings.yaml` — the Flux Kustomization CR (sops decryption) reconciling
+  `settings/<name>/`, where the actual ConfigMap/Secret live
+- One Kustomization per infrastructure component and app, `substituteFrom: cluster-settings`
 
-`clusters/<name>/` has no root `kustomization.yaml` of its own — Flux auto-generates
-one by walking the directory, which is why `settings/<name>/` lives *outside*
-`clusters/<name>/`: if it were nested inside, the auto-generated root Kustomization
-would apply it too, without the sops decryption only the dedicated `cluster-settings`
-Kustomization CR has, racing the two on every reconcile.
+`clusters/<name>/` has no root `kustomization.yaml` — Flux auto-generates one by
+walking the directory. `settings/<name>/` lives outside `clusters/<name>/` so that
+walk (no decryption config) can't apply it racing the dedicated Kustomization that does.
 
-Flux reconciles `clusters/<name>/` → which creates Kustomizations for each component → which render and apply the manifests in `infrastructure/`, `apps/`, and `settings/<name>/`.
+Flux reconciles `clusters/<name>/` → Kustomizations per component → manifests in
+`infrastructure/`, `apps/`, and `settings/<name>/`.
 
 ## Variable Substitution
 

--- a/kubernetes/apps/home-automation/README.md
+++ b/kubernetes/apps/home-automation/README.md
@@ -1,10 +1,7 @@
 # home-automation
 
-MQTT stack: Mosquitto as the broker, Zigbee2MQTT for Zigbee device
-integration. Not currently wired into any cluster — kept from the
-decommissioned na cluster pending migration to orion. (Home Assistant was
-also part of this stack; its manifests were removed as orphaned — never
-wired into a cluster.)
+MQTT stack: Mosquitto (broker) + Zigbee2MQTT (Zigbee bridge). Not wired into
+any cluster — kept from the decommissioned na cluster pending migration.
 
 ## Components
 
@@ -13,14 +10,10 @@ wired into a cluster.)
 | `mosquitto/` | MQTT message broker |
 | `zigbee2mqtt/` | Zigbee coordinator bridge → MQTT |
 
-## Configuration
+## Config
 
-Each component has its own `kustomization.yaml`, `deploy.yaml`, and `configMap.yaml`. Zigbee2MQTT publishes to Mosquitto.
-
-## Dependencies
-
-`mosquitto` must be ready before `zigbee2mqtt` attempts to connect to the broker.
+Zigbee2MQTT publishes to Mosquitto; `mosquitto` must be ready first.
 
 ## Troubleshooting
 
-- **MQTT broker unreachable:** Verify the `mosquitto` Service and that credentials in `configMap.yaml` match what clients are using.
+- **MQTT broker unreachable:** check the `mosquitto` Service and that `configMap.yaml` credentials match what clients use.

--- a/kubernetes/infrastructure/README.md
+++ b/kubernetes/infrastructure/README.md
@@ -18,7 +18,7 @@ Shared HelmRelease and Kustomize building blocks consumed by any cluster. Each c
 | rbac | Cluster RBAC | — |
 | [weave-gitops](weave-gitops/README.md) | Flux CD web UI (na-only, pending migration to orion) | `flux-system` |
 
-*(Components without a linked README don't have one yet — tracked for the docs cleanup pass.)*
+*(Unlinked = no README yet.)*
 
 ## Dependency Order
 

--- a/scripts/flux-build.sh
+++ b/scripts/flux-build.sh
@@ -15,13 +15,9 @@ set -euo pipefail
 CLUSTER="${1:-orion}"
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 CLUSTER_DIR="$REPO_ROOT/kubernetes/clusters/$CLUSTER"
-# settings/ deliberately lives outside CLUSTER_DIR, at kubernetes/settings/<cluster>/,
-# not kubernetes/clusters/<cluster>/settings/ — so it's never swept up by
-# kustomize-controller's implicit directory walk of CLUSTER_DIR (the path the
-# cluster's root Kustomization/flux-system reconciles), which has no sops
-# decryption config. It's reconciled solely by its own dedicated
-# cluster-settings Kustomization CR (kubernetes/clusters/<cluster>/cluster-settings.yaml),
-# which does have decryption configured.
+# settings/ lives outside CLUSTER_DIR (kubernetes/settings/<cluster>/, not
+# kubernetes/clusters/<cluster>/settings/) so Flux's implicit directory walk
+# of CLUSTER_DIR never applies it without decryption.
 SETTINGS_DIR="$REPO_ROOT/kubernetes/settings/$CLUSTER"
 
 command -v kustomize >/dev/null 2>&1 || { echo "ERROR: kustomize not found. Run: task gen:tools" >&2; exit 1; }
@@ -88,12 +84,9 @@ KUSTOMIZE_FLAGS=("--load-restrictor=LoadRestrictionsNone")
 for ks_file in $(find "$CLUSTER_DIR" -maxdepth 3 -name '*.yaml' \
     -not -path '*/flux-system/*' | sort); do
 
-  # Extract name|path|substitute for every Flux Kustomization object in this
-  # file. `substitute` is spec.postBuild.substitute (literal key=value pairs
-  # inline on the CR, e.g. appName/subdomain) — distinct from substituteFrom
-  # (the ConfigMap/Secret handled above) and just as required for a faithful
-  # render. Files can contain multiple YAML documents (e.g. cert-manager +
-  # cert-manager-issuers).
+  # name|path|substitute per Kustomization object (files may hold multiple
+  # documents). substitute = spec.postBuild.substitute literals, separate
+  # from the ConfigMap/Secret substituteFrom handled above.
   while IFS='|' read -r name path substitute; do
     [[ -z "$name" || "$name" == "null" ]] && continue
     [[ -z "$path" || "$path" == "null" ]] && continue
@@ -109,8 +102,7 @@ for ks_file in $(find "$CLUSTER_DIR" -maxdepth 3 -name '*.yaml' \
       continue
     }
 
-    # postBuild.substitute literals are scoped to this Kustomization only —
-    # export them for this build, then unset so they don't leak into the next.
+    # scoped to this Kustomization only; unset after building
     LITERAL_KEYS=()
     if [[ -n "$substitute" ]]; then
       IFS=';' read -ra pairs <<< "$substitute"
@@ -124,8 +116,7 @@ for ks_file in $(find "$CLUSTER_DIR" -maxdepth 3 -name '*.yaml' \
     fi
 
     if RENDERED="$(kustomize build "$BUILD_PATH" "${KUSTOMIZE_FLAGS[@]}" | python3 -c "$ENVSUBST_PY")"; then
-      # kustomize build succeeding says nothing about substitution — check
-      # separately for ${VAR} placeholders that never got resolved.
+      # a successful build doesn't mean substitution succeeded — check for leftovers
       UNRESOLVED="$(printf '%s' "$RENDERED" | grep -oE '\$\{[A-Za-z_][A-Za-z0-9_]*(:[^}]*)?\}' | sort -u || true)"
       if [[ -n "$UNRESOLVED" ]]; then
         echo "  ✗ $name — unresolved variable(s):"


### PR DESCRIPTION
Cleanup pass over PRs #71–#74: several comments and READMEs added during the refactor were over-explanatory. Condensed to state the fact/rule once, cut repeated rationale and historical narrative that isn't operationally relevant. No behavior change.

Doesn't touch anything in #75 (still open) — those docs were condensed directly on that branch instead, to avoid conflicts.

Verified: `task test:build` 14/14, `task gen:validate` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)