### PR TITLE
feat: add Homepage link dashboard for orion

### DIFF
--- a/kubernetes/apps/pihole/overlays/orion/kustomization.yaml
+++ b/kubernetes/apps/pihole/overlays/orion/kustomization.yaml
@@ -10,3 +10,11 @@ resources:
 
 components:
   - ../../../webapp/components/httproute
+
+# gethomepage.dev discovery for the homepage dashboard; component's
+# HTTPRoute is generic and takes no annotations of its own.
+patches:
+  - path: patches/httproute-add-homepage-annotations.yaml
+    target:
+      kind: HTTPRoute
+      name: route

--- a/kubernetes/apps/pihole/overlays/orion/patches/httproute-add-homepage-annotations.yaml
+++ b/kubernetes/apps/pihole/overlays/orion/patches/httproute-add-homepage-annotations.yaml
@@ -1,0 +1,10 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: route
+  annotations:
+    gethomepage.dev/enabled: "true"
+    gethomepage.dev/name: "Pi-hole"
+    gethomepage.dev/description: "DNS / ad-block"
+    gethomepage.dev/group: "Network"
+    gethomepage.dev/icon: "pi-hole.png"

--- a/kubernetes/clusters/orion/homepage.yaml
+++ b/kubernetes/clusters/orion/homepage.yaml
@@ -1,0 +1,21 @@
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: homepage
+  namespace: flux-system
+spec:
+  dependsOn:
+    - name: cluster-settings
+  interval: 1h
+  retryInterval: 1m
+  timeout: 5m
+  prune: true
+  wait: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+  path: ./kubernetes/infrastructure/homepage
+  postBuild:
+    substituteFrom:
+      - kind: ConfigMap
+        name: cluster-settings

--- a/kubernetes/infrastructure/README.md
+++ b/kubernetes/infrastructure/README.md
@@ -10,6 +10,7 @@ Shared HelmRelease and Kustomize building blocks consumed by any cluster. Each c
 | [cert-manager](cert-manager/README.md) | TLS certificate issuance (Let's Encrypt via Cloudflare DNS) | `cert-manager` |
 | [vkms](vkms/README.md) | VictoriaMetrics observability stack (Grafana, vmagent, vmalert, vmsingle, Alertmanager) | `monitoring` |
 | [headlamp](headlamp/README.md) | Cluster dashboard (workloads, CRDs, logs, exec), read-only RBAC | `headlamp` |
+| [homepage](homepage/README.md) | Link dashboard, auto-discovers HTTPRoutes via annotations | `homepage` |
 | rook-ceph-operator | Ceph operator | `rook-ceph` |
 | rook-ceph-cluster | Ceph cluster (default block storage) | `rook-ceph` |
 | gateway-api | Gateway API CRDs | `gateway-system` |

--- a/kubernetes/infrastructure/gateway/ceph-dashboard-httproute.yaml
+++ b/kubernetes/infrastructure/gateway/ceph-dashboard-httproute.yaml
@@ -3,6 +3,12 @@ kind: HTTPRoute
 metadata:
   name: ceph-dashboard
   namespace: gateway
+  annotations:
+    gethomepage.dev/enabled: "true"
+    gethomepage.dev/name: "Ceph"
+    gethomepage.dev/description: "Storage cluster health"
+    gethomepage.dev/group: "Cluster"
+    gethomepage.dev/icon: "ceph.png"
 spec:
   parentRefs:
     - name: orion

--- a/kubernetes/infrastructure/gateway/homepage-httproute.yaml
+++ b/kubernetes/infrastructure/gateway/homepage-httproute.yaml
@@ -1,26 +1,26 @@
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
-  name: headlamp
-  namespace: headlamp
+  name: homepage
+  namespace: homepage
   annotations:
     gethomepage.dev/enabled: "true"
-    gethomepage.dev/name: "Headlamp"
-    gethomepage.dev/description: "Cluster dashboard"
+    gethomepage.dev/name: "Homepage"
+    gethomepage.dev/description: "This dashboard"
     gethomepage.dev/group: "Cluster"
-    gethomepage.dev/icon: "kubernetes.png"
+    gethomepage.dev/icon: "homepage.png"
 spec:
   parentRefs:
     - name: orion
       namespace: gateway
       sectionName: https
   hostnames:
-    - "headlamp.${domain}"
+    - "homepage.${domain}"
   rules:
     - matches:
         - path:
             type: PathPrefix
             value: /
       backendRefs:
-        - name: headlamp
-          port: 80
+        - name: homepage
+          port: 3000

--- a/kubernetes/infrastructure/gateway/hubble-httproute.yaml
+++ b/kubernetes/infrastructure/gateway/hubble-httproute.yaml
@@ -3,6 +3,12 @@ kind: HTTPRoute
 metadata:
   name: hubble-ui
   namespace: cilium
+  annotations:
+    gethomepage.dev/enabled: "true"
+    gethomepage.dev/name: "Hubble"
+    gethomepage.dev/description: "Cilium network observability"
+    gethomepage.dev/group: "Cluster"
+    gethomepage.dev/icon: "cilium.png"
 spec:
   parentRefs:
     - name: orion

--- a/kubernetes/infrastructure/gateway/kustomization.yaml
+++ b/kubernetes/infrastructure/gateway/kustomization.yaml
@@ -7,5 +7,6 @@ resources:
   - hubble-httproute.yaml
   - ceph-dashboard-httproute.yaml
   - headlamp-httproute.yaml
+  - homepage-httproute.yaml
   - http-redirect.yaml
   - reference-grant.yaml

--- a/kubernetes/infrastructure/homepage/README.md
+++ b/kubernetes/infrastructure/homepage/README.md
@@ -1,0 +1,38 @@
+# homepage
+
+Link dashboard ([gethomepage/homepage](https://gethomepage.dev)) for orion —
+one page linking out to every service instead of bookmarking each host.
+
+## Configuration
+
+- **Chart:** `homepage` from the `jameswynn/helm-charts` repo (pinned in
+  `release.yaml`) — wraps the upstream `ghcr.io/gethomepage/homepage` image.
+- **Namespace:** `homepage`
+- **Values source:** ConfigMap (`values.yaml` via kustomize `configMapGenerator`)
+
+Services aren't hand-listed here. `config.kubernetes.mode: cluster` +
+`gateway: true` turns on live discovery of `HTTPRoute` resources cluster-wide;
+each route opts in via `gethomepage.dev/*` annotations (see
+`infrastructure/gateway/*-httproute.yaml` and `apps/pihole/overlays/orion`).
+Add the same annotations to any new HTTPRoute to get it listed for free.
+
+`enableRbac: true` grants the chart's own `ClusterRole` — read-only
+get/list on namespaces/pods/nodes/ingresses/httproutes/gateways, nothing
+that can mutate cluster state.
+
+## Dependencies
+
+Cilium (Gateway API) must be running. No secrets, no decryption needed.
+`HOMEPAGE_ALLOWED_HOSTS` is substituted from `cluster-settings` at
+reconcile time (`clusters/orion/homepage.yaml`), same as `${domain}`
+elsewhere.
+
+## Ingress / Endpoints
+
+`homepage.${domain}` — HTTPRoute lives in `infrastructure/gateway/`
+(same-namespace backend, mirrors `headlamp`).
+
+## Access
+
+No login — the dashboard is just outbound links plus read-only cluster
+widgets, nothing sensitive to gate.

--- a/kubernetes/infrastructure/homepage/kustomization.yaml
+++ b/kubernetes/infrastructure/homepage/kustomization.yaml
@@ -1,0 +1,15 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: homepage
+resources:
+  - namespace.yaml
+  - repository.yaml
+  - release.yaml
+
+configMapGenerator:
+- name: homepage-helm-chart-values
+  files:
+  - values.yaml
+
+configurations:
+  - kustomizeconfig.yaml

--- a/kubernetes/infrastructure/homepage/kustomizeconfig.yaml
+++ b/kubernetes/infrastructure/homepage/kustomizeconfig.yaml
@@ -1,0 +1,6 @@
+nameReference:
+- kind: ConfigMap
+  version: v1
+  fieldSpecs:
+  - path: spec/valuesFrom/name
+    kind: HelmRelease

--- a/kubernetes/infrastructure/homepage/namespace.yaml
+++ b/kubernetes/infrastructure/homepage/namespace.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: homepage
+  labels:
+    gateway.networking.k8s.io/access: "true"

--- a/kubernetes/infrastructure/homepage/release.yaml
+++ b/kubernetes/infrastructure/homepage/release.yaml
@@ -1,0 +1,25 @@
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: homepage
+  namespace: homepage
+spec:
+  interval: 1h
+  chart:
+    spec:
+      chart: homepage
+      version: "2.1.0"
+      sourceRef:
+        kind: HelmRepository
+        name: homepage
+      interval: 1h
+  install:
+    remediation:
+      retries: 3
+  upgrade:
+    remediation:
+      retries: 3
+  valuesFrom:
+    - kind: ConfigMap
+      name: homepage-helm-chart-values
+      valuesKey: values.yaml

--- a/kubernetes/infrastructure/homepage/repository.yaml
+++ b/kubernetes/infrastructure/homepage/repository.yaml
@@ -1,0 +1,8 @@
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: HelmRepository
+metadata:
+  name: homepage
+  namespace: homepage
+spec:
+  url: https://jameswynn.github.io/helm-charts
+  interval: 1h

--- a/kubernetes/infrastructure/homepage/values.yaml
+++ b/kubernetes/infrastructure/homepage/values.yaml
@@ -1,0 +1,37 @@
+# Read-only cluster discovery: lets Homepage list services from HTTPRoute
+# annotations instead of a hand-maintained link list. ClusterRole (chart's
+# own, via enableRbac) only grants get/list on namespaces/pods/nodes/
+# ingresses/httproutes/gateways — no write access, matching the
+# "changes go through git+Flux" convention for this repo.
+enableRbac: true
+
+serviceAccount:
+  create: true
+
+env:
+  - name: HOMEPAGE_ALLOWED_HOSTS
+    value: "homepage.${domain}"
+
+config:
+  kubernetes:
+    mode: cluster
+    gateway: true
+
+  # Populated via gethomepage.dev/* annotations on each HTTPRoute instead of
+  # a static list here — see infrastructure/gateway/*-httproute.yaml.
+  services:
+  bookmarks:
+
+  widgets:
+    - resources:
+        backend: resources
+        expanded: true
+        cpu: true
+        memory: true
+    - search:
+        provider: duckduckgo
+        target: _blank
+
+  settingsString: |
+    title: orion
+    headerStyle: boxed


### PR DESCRIPTION
## Summary
Adds [Homepage](https://gethomepage.dev) (via the `jameswynn/helm-charts` chart) as a link dashboard for orion at `homepage.${domain}`, following the same infra pattern as `headlamp`.

Rather than a hand-maintained link list, services are discovered live from `HTTPRoute` resources cluster-wide via `gethomepage.dev/*` annotations (`config.kubernetes: mode=cluster, gateway=true`). Annotated the four existing HTTPRoutes so they show up immediately:
- headlamp, hubble-ui, ceph-dashboard — direct annotation
- pihole — via a patch, since its route comes from the shared `webapp/components/httproute` template

Any future HTTPRoute picks this up for free by adding the same annotations.

RBAC is the chart's own read-only `ClusterRole` (`enableRbac: true`) — get/list on namespaces/pods/nodes/ingresses/httproutes/gateways only, no write access.

## Verification
- `task gen:validate` — pass
- `task test:build` — 16/16 Kustomizations render, `${domain}` resolves correctly
- `task test:kind-up/push/reconcile/down` — HelmRelease installed, pod ran, ClusterRole/ClusterRoleBinding created, and `HOMEPAGE_ALLOWED_HOSTS` resolved to `homepage.orion.norseamerican.com` in the live pod spec

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a Homepage dashboard for centralized access to infrastructure services.
  - Added secure HTTPS routing for the dashboard at the configured Homepage address.
  - Enabled automatic discovery of Pi-hole, Ceph, Headlamp, and Hubble services.
  - Added service metadata including names, descriptions, groups, icons, and availability status.
  - Configured Kubernetes resource and gateway discovery, search, and dashboard widgets.
- **Documentation**
  - Documented Homepage deployment, routing, discovery, permissions, and configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->