### PR TITLE
feat: add external-endpoints for cluster-external hosts

### DIFF
--- a/kubernetes/apps/external-endpoints/README.md
+++ b/kubernetes/apps/external-endpoints/README.md
@@ -32,3 +32,26 @@ sed -i '' \
 Then add `<name>` to `resources:` in `../kustomization.yaml`. No new Flux
 Kustomization, no namespace, no cert — it rides the existing ones. Run
 `task gen:validate` before pushing.
+
+## HTTPS-only backends
+
+The template assumes the backend speaks plain HTTP — the Gateway terminates
+TLS and forwards plaintext, same as every other app on orion. Some
+appliances (Unifi's controller UI, most BMCs/IPMI) only serve HTTPS,
+usually with a self-signed cert, and won't answer a plaintext request at
+all. For those:
+
+1. Pull the device's cert into a ConfigMap (`ca.crt` key) — not a secret,
+   it's a public leaf cert. `unifi/configmap-ca.yaml` documents the
+   `openssl s_client` one-liner used to fetch it.
+2. Add the `../_components/backend-tls` component and patch its
+   `BackendTLSPolicy` to point at your Service/ConfigMap names — see
+   `unifi/kustomization.yaml`.
+3. Set `validation.hostname` to whatever SAN the cert actually presents
+   (check with `openssl x509 -noout -ext subjectAltName`), not the
+   device's real hostname or the external `${domain}` — Envoy validates
+   the re-encrypted hop against that SAN, independent of the public
+   HTTPRoute hostname.
+
+Re-run the cert pull and update the ConfigMap if the device ever rotates
+its certificate.

--- a/kubernetes/apps/external-endpoints/README.md
+++ b/kubernetes/apps/external-endpoints/README.md
@@ -1,0 +1,34 @@
+# external-endpoints
+
+Routes cluster-external hosts (LAN devices, VMs, anything not running as a
+Pod) through the orion Gateway with a real cert, using the standard
+Kubernetes "Service without selector" pattern: a Service with no selector
+paired with a hand-written EndpointSlice pointing at the external IP. TLS
+comes from the Gateway's existing wildcard cert — no per-app Certificate
+needed. This has nothing Cilium-specific about it beyond Cilium being the
+Gateway API implementation; it's plain Kubernetes.
+
+All forwarded hosts share one namespace (`external-endpoints`) and one Flux
+Kustomization, since none of this owns Pods, PVCs, or secrets worth
+isolating — see `opensprinkler/` for a working example.
+
+## Adding one
+
+```bash
+cp -r kubernetes/apps/external-endpoints/_template kubernetes/apps/external-endpoints/<name>
+cd kubernetes/apps/external-endpoints/<name>
+for f in *.tmpl; do mv "$f" "${f%.tmpl}"; done
+sed -i '' \
+  -e 's/__NAME__/<name>/g' \
+  -e 's/__ADDRESS__/<ip>/g' \
+  -e 's/__PORT__/<port>/g' \
+  -e 's/__SUBDOMAIN__/<subdomain>/g' \
+  -e 's/__DISPLAY_NAME__/<Display Name>/g' \
+  -e 's/__DESCRIPTION__/<description>/g' \
+  -e 's/__ICON__/<icon>.png/g' \
+  *.yaml
+```
+
+Then add `<name>` to `resources:` in `../kustomization.yaml`. No new Flux
+Kustomization, no namespace, no cert — it rides the existing ones. Run
+`task gen:validate` before pushing.

--- a/kubernetes/apps/external-endpoints/_components/backend-tls/backendtlspolicy.yaml
+++ b/kubernetes/apps/external-endpoints/_components/backend-tls/backendtlspolicy.yaml
@@ -1,0 +1,15 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: BackendTLSPolicy
+metadata:
+  name: backend-tls
+spec:
+  targetRefs:
+    - group: ""
+      kind: Service
+      name: REPLACE_SERVICE_NAME
+  validation:
+    caCertificateRefs:
+      - group: ""
+        kind: ConfigMap
+        name: REPLACE_CA_CONFIGMAP_NAME
+    hostname: replace-hostname

--- a/kubernetes/apps/external-endpoints/_components/backend-tls/kustomization.yaml
+++ b/kubernetes/apps/external-endpoints/_components/backend-tls/kustomization.yaml
@@ -1,0 +1,10 @@
+# For HTTPS-only backends (Unifi's controller UI, most BMCs/IPMI): tells
+# the Gateway to re-encrypt to the backend instead of forwarding plaintext.
+# Consumer must patch spec.targetRefs[0].name, spec.validation.hostname,
+# and spec.validation.caCertificateRefs[0].name — see ../../unifi and
+# ../../README.md.
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+
+resources:
+  - backendtlspolicy.yaml

--- a/kubernetes/apps/external-endpoints/_template/endpointslice.yaml.tmpl
+++ b/kubernetes/apps/external-endpoints/_template/endpointslice.yaml.tmpl
@@ -1,0 +1,16 @@
+# Binds to service.yaml via the kubernetes.io/service-name label — that's
+# the only link, the EndpointSlice's own name doesn't matter.
+apiVersion: discovery.k8s.io/v1
+kind: EndpointSlice
+metadata:
+  name: __NAME__
+  labels:
+    kubernetes.io/service-name: __NAME__
+addressType: IPv4
+ports:
+  - name: http
+    protocol: TCP
+    port: __PORT__
+endpoints:
+  - addresses:
+      - __ADDRESS__

--- a/kubernetes/apps/external-endpoints/_template/httproute.yaml.tmpl
+++ b/kubernetes/apps/external-endpoints/_template/httproute.yaml.tmpl
@@ -1,0 +1,21 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: __NAME__
+  annotations:
+    gethomepage.dev/enabled: "true"
+    gethomepage.dev/name: "__DISPLAY_NAME__"
+    gethomepage.dev/description: "__DESCRIPTION__"
+    gethomepage.dev/group: "Home"
+    gethomepage.dev/icon: "__ICON__"
+spec:
+  parentRefs:
+    - name: ${gatewayName}
+      namespace: gateway
+      sectionName: https
+  hostnames:
+    - "__SUBDOMAIN__.${domain}"
+  rules:
+    - backendRefs:
+        - name: __NAME__
+          port: __PORT__

--- a/kubernetes/apps/external-endpoints/_template/kustomization.yaml.tmpl
+++ b/kubernetes/apps/external-endpoints/_template/kustomization.yaml.tmpl
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - service.yaml
+  - endpointslice.yaml
+  - httproute.yaml

--- a/kubernetes/apps/external-endpoints/_template/service.yaml.tmpl
+++ b/kubernetes/apps/external-endpoints/_template/service.yaml.tmpl
@@ -1,0 +1,11 @@
+# No selector: Kubernetes leaves endpoints alone, endpointslice.yaml
+# supplies them by hand ("Service without selector" pattern).
+apiVersion: v1
+kind: Service
+metadata:
+  name: __NAME__
+spec:
+  ports:
+    - port: __PORT__
+      protocol: TCP
+      name: http

--- a/kubernetes/apps/external-endpoints/kustomization.yaml
+++ b/kubernetes/apps/external-endpoints/kustomization.yaml
@@ -1,0 +1,9 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: external-endpoints
+
+resources:
+  - namespace.yaml
+  - opensprinkler
+  # - _template is a copy-and-edit starting point, not a resource — see README.md

--- a/kubernetes/apps/external-endpoints/kustomization.yaml
+++ b/kubernetes/apps/external-endpoints/kustomization.yaml
@@ -6,4 +6,7 @@ namespace: external-endpoints
 resources:
   - namespace.yaml
   - opensprinkler
+  - slzb-06
+  - truenas
+  - unifi
   # - _template is a copy-and-edit starting point, not a resource — see README.md

--- a/kubernetes/apps/external-endpoints/kustomization.yaml
+++ b/kubernetes/apps/external-endpoints/kustomization.yaml
@@ -9,4 +9,5 @@ resources:
   - slzb-06
   - truenas
   - unifi
+  - neurio
   # - _template is a copy-and-edit starting point, not a resource — see README.md

--- a/kubernetes/apps/external-endpoints/namespace.yaml
+++ b/kubernetes/apps/external-endpoints/namespace.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: external-endpoints
+  labels:
+    gateway.networking.k8s.io/access: "true"

--- a/kubernetes/apps/external-endpoints/neurio/endpointslice.yaml
+++ b/kubernetes/apps/external-endpoints/neurio/endpointslice.yaml
@@ -1,0 +1,16 @@
+# Binds to service.yaml via the kubernetes.io/service-name label — that's
+# the only link, the EndpointSlice's own name doesn't matter.
+apiVersion: discovery.k8s.io/v1
+kind: EndpointSlice
+metadata:
+  name: neurio
+  labels:
+    kubernetes.io/service-name: neurio
+addressType: IPv4
+ports:
+  - name: http
+    protocol: TCP
+    port: 80
+endpoints:
+  - addresses:
+      - 10.30.0.217

--- a/kubernetes/apps/external-endpoints/neurio/httproute.yaml
+++ b/kubernetes/apps/external-endpoints/neurio/httproute.yaml
@@ -1,0 +1,21 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: neurio
+  annotations:
+    gethomepage.dev/enabled: "true"
+    gethomepage.dev/name: "Neurio"
+    gethomepage.dev/description: "Home power monitor"
+    gethomepage.dev/group: "Energy"
+    gethomepage.dev/icon: "neurio.png"
+spec:
+  parentRefs:
+    - name: ${gatewayName}
+      namespace: gateway
+      sectionName: https
+  hostnames:
+    - "power.${domain}"
+  rules:
+    - backendRefs:
+        - name: neurio
+          port: 80

--- a/kubernetes/apps/external-endpoints/neurio/kustomization.yaml
+++ b/kubernetes/apps/external-endpoints/neurio/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - service.yaml
+  - endpointslice.yaml
+  - httproute.yaml

--- a/kubernetes/apps/external-endpoints/neurio/service.yaml
+++ b/kubernetes/apps/external-endpoints/neurio/service.yaml
@@ -1,0 +1,11 @@
+# No selector: Kubernetes leaves endpoints alone, endpointslice.yaml
+# supplies them by hand ("Service without selector" pattern).
+apiVersion: v1
+kind: Service
+metadata:
+  name: neurio
+spec:
+  ports:
+    - port: 80
+      protocol: TCP
+      name: http

--- a/kubernetes/apps/external-endpoints/opensprinkler/endpointslice.yaml
+++ b/kubernetes/apps/external-endpoints/opensprinkler/endpointslice.yaml
@@ -1,0 +1,16 @@
+# Binds to service.yaml via the kubernetes.io/service-name label — that's
+# the only link, the EndpointSlice's own name doesn't matter.
+apiVersion: discovery.k8s.io/v1
+kind: EndpointSlice
+metadata:
+  name: opensprinkler
+  labels:
+    kubernetes.io/service-name: opensprinkler
+addressType: IPv4
+ports:
+  - name: http
+    protocol: TCP
+    port: 80
+endpoints:
+  - addresses:
+      - 10.30.0.249

--- a/kubernetes/apps/external-endpoints/opensprinkler/httproute.yaml
+++ b/kubernetes/apps/external-endpoints/opensprinkler/httproute.yaml
@@ -1,0 +1,21 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: opensprinkler
+  annotations:
+    gethomepage.dev/enabled: "true"
+    gethomepage.dev/name: "OpenSprinkler"
+    gethomepage.dev/description: "Irrigation controller"
+    gethomepage.dev/group: "Home"
+    gethomepage.dev/icon: "opensprinkler.png"
+spec:
+  parentRefs:
+    - name: ${gatewayName}
+      namespace: gateway
+      sectionName: https
+  hostnames:
+    - "sprinkler.${domain}"
+  rules:
+    - backendRefs:
+        - name: opensprinkler
+          port: 80

--- a/kubernetes/apps/external-endpoints/opensprinkler/kustomization.yaml
+++ b/kubernetes/apps/external-endpoints/opensprinkler/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - service.yaml
+  - endpointslice.yaml
+  - httproute.yaml

--- a/kubernetes/apps/external-endpoints/opensprinkler/service.yaml
+++ b/kubernetes/apps/external-endpoints/opensprinkler/service.yaml
@@ -1,0 +1,11 @@
+# No selector: Kubernetes leaves endpoints alone, endpointslice.yaml
+# supplies them by hand ("Service without selector" pattern).
+apiVersion: v1
+kind: Service
+metadata:
+  name: opensprinkler
+spec:
+  ports:
+    - port: 80
+      protocol: TCP
+      name: http

--- a/kubernetes/apps/external-endpoints/slzb-06/endpointslice.yaml
+++ b/kubernetes/apps/external-endpoints/slzb-06/endpointslice.yaml
@@ -1,0 +1,16 @@
+# Binds to service.yaml via the kubernetes.io/service-name label — that's
+# the only link, the EndpointSlice's own name doesn't matter.
+apiVersion: discovery.k8s.io/v1
+kind: EndpointSlice
+metadata:
+  name: slzb-06
+  labels:
+    kubernetes.io/service-name: slzb-06
+addressType: IPv4
+ports:
+  - name: http
+    protocol: TCP
+    port: 80
+endpoints:
+  - addresses:
+      - 10.50.0.150

--- a/kubernetes/apps/external-endpoints/slzb-06/httproute.yaml
+++ b/kubernetes/apps/external-endpoints/slzb-06/httproute.yaml
@@ -1,0 +1,21 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: slzb-06
+  annotations:
+    gethomepage.dev/enabled: "true"
+    gethomepage.dev/name: "SLZB-06"
+    gethomepage.dev/description: "Zigbee-to-Ethernet coordinator for Home Assistant"
+    gethomepage.dev/group: "Home Automation"
+    gethomepage.dev/icon: "smlight.png"
+spec:
+  parentRefs:
+    - name: ${gatewayName}
+      namespace: gateway
+      sectionName: https
+  hostnames:
+    - "zigbee.${domain}"
+  rules:
+    - backendRefs:
+        - name: slzb-06
+          port: 80

--- a/kubernetes/apps/external-endpoints/slzb-06/kustomization.yaml
+++ b/kubernetes/apps/external-endpoints/slzb-06/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - service.yaml
+  - endpointslice.yaml
+  - httproute.yaml

--- a/kubernetes/apps/external-endpoints/slzb-06/service.yaml
+++ b/kubernetes/apps/external-endpoints/slzb-06/service.yaml
@@ -1,0 +1,11 @@
+# No selector: Kubernetes leaves endpoints alone, endpointslice.yaml
+# supplies them by hand ("Service without selector" pattern).
+apiVersion: v1
+kind: Service
+metadata:
+  name: slzb-06
+spec:
+  ports:
+    - port: 80
+      protocol: TCP
+      name: http

--- a/kubernetes/apps/external-endpoints/truenas/endpointslice.yaml
+++ b/kubernetes/apps/external-endpoints/truenas/endpointslice.yaml
@@ -1,0 +1,16 @@
+# Binds to service.yaml via the kubernetes.io/service-name label — that's
+# the only link, the EndpointSlice's own name doesn't matter.
+apiVersion: discovery.k8s.io/v1
+kind: EndpointSlice
+metadata:
+  name: truenas
+  labels:
+    kubernetes.io/service-name: truenas
+addressType: IPv4
+ports:
+  - name: http
+    protocol: TCP
+    port: 80
+endpoints:
+  - addresses:
+      - 10.50.0.212

--- a/kubernetes/apps/external-endpoints/truenas/httproute.yaml
+++ b/kubernetes/apps/external-endpoints/truenas/httproute.yaml
@@ -1,0 +1,21 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: truenas
+  annotations:
+    gethomepage.dev/enabled: "true"
+    gethomepage.dev/name: "TrueNAS"
+    gethomepage.dev/description: "NAS"
+    gethomepage.dev/group: "Storage"
+    gethomepage.dev/icon: "truenas.png"
+spec:
+  parentRefs:
+    - name: ${gatewayName}
+      namespace: gateway
+      sectionName: https
+  hostnames:
+    - "nas.${domain}"
+  rules:
+    - backendRefs:
+        - name: truenas
+          port: 80

--- a/kubernetes/apps/external-endpoints/truenas/kustomization.yaml
+++ b/kubernetes/apps/external-endpoints/truenas/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - service.yaml
+  - endpointslice.yaml
+  - httproute.yaml

--- a/kubernetes/apps/external-endpoints/truenas/service.yaml
+++ b/kubernetes/apps/external-endpoints/truenas/service.yaml
@@ -1,0 +1,11 @@
+# No selector: Kubernetes leaves endpoints alone, endpointslice.yaml
+# supplies them by hand ("Service without selector" pattern).
+apiVersion: v1
+kind: Service
+metadata:
+  name: truenas
+spec:
+  ports:
+    - port: 80
+      protocol: TCP
+      name: http

--- a/kubernetes/apps/external-endpoints/unifi/configmap-ca.yaml
+++ b/kubernetes/apps/external-endpoints/unifi/configmap-ca.yaml
@@ -1,0 +1,33 @@
+# Unifi's own self-signed leaf cert, trusted as its own CA (chain of one) so
+# BackendTLSPolicy can validate the re-encrypted hop to it. Pulled with:
+#   echo | openssl s_client -connect 10.20.0.1:8443 -servername 10.20.0.1 \
+#     2>/dev/null | openssl x509 > ca.crt
+# Re-run and update if the controller's cert is ever regenerated (currently
+# valid to 2027-09-16; not a secret, it's a public leaf cert).
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: unifi-ca
+data:
+  ca.crt: |
+    -----BEGIN CERTIFICATE-----
+    MIIDfTCCAmWgAwIBAgIEaEvCKjANBgkqhkiG9w0BAQsFADBrMQswCQYDVQQGEwJV
+    UzERMA8GA1UECAwITmV3IFlvcmsxETAPBgNVBAcMCE5ldyBZb3JrMRYwFAYDVQQK
+    DA1VYmlxdWl0aSBJbmMuMQ4wDAYDVQQLDAVVbmlGaTEOMAwGA1UEAwwFVW5pRmkw
+    HhcNMjUwNjEzMDYxNjEwWhcNMjcwOTE2MDYxNjEwWjBrMQswCQYDVQQGEwJVUzER
+    MA8GA1UECAwITmV3IFlvcmsxETAPBgNVBAcMCE5ldyBZb3JrMRYwFAYDVQQKDA1V
+    YmlxdWl0aSBJbmMuMQ4wDAYDVQQLDAVVbmlGaTEOMAwGA1UEAwwFVW5pRmkwggEi
+    MA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDRV5s1WWO+Gm5GP70G+9WHUYGY
+    PlLqzrVfZ5bGsY4xj7iQB9nWVmBFq0yk+J5YWqBCedb38I9GXryS2RnAMOwoW8SB
+    E0I1XjDvIxjcVVcP1RKUlxznI2rwlVqmW3MvK7cBAlDB4hIujtIDD9pe8mFQ9aux
+    loecD63UkvdDVNrMwpSt0Ymz/VcEixZGZuPEzWJAx7+xgDDEg5TuExOCHxy/iFK2
+    KsOtMbBFnmuywrVXfQZa8PMNalpYtvlQSaJmZFJZn6PVRIJYUJ/FmwDfaVmgaxVi
+    LTQJdg88G9nM1Bdna6sq6I/aW+/MpgnlcCv8cohIqXWi3yOTaMqGo2elXUyhAgMB
+    AAGjKTAnMBAGA1UdEQQJMAeCBVVuaUZpMBMGA1UdJQQMMAoGCCsGAQUFBwMBMA0G
+    CSqGSIb3DQEBCwUAA4IBAQBKqeVe6BKxhQOCLZqGrbHB/pfKsh0mMtJeBh1aOFMK
+    1qScHMzndgZHOqQL/fk1NTWWdNc1fWlTLvkjRsEFUiBa60bNWOaRErtvARutooR3
+    zIzweNkVp5/8UbveySvzSjXuwXmVRJi7UMYGbx5Np51W0UWZxmn1ceG/Zclbpwjo
+    Jbs8U9w+ca4pyaGUob+Bs1Ub0OLfLXzBBYhCL33FTWTdaWtuMH7Vpy9w1SqnvDF/
+    A6Ya5EVpb8IvrIxnDYvaTIHqTxeOjACG3KTVvmrgbCfeFgusyhYPjjOV6OduXTmI
+    VAeRJa90lWKE3xb+V5WyiFmFE0nGhqbiAL3Xn3dC5QnL
+    -----END CERTIFICATE-----

--- a/kubernetes/apps/external-endpoints/unifi/endpointslice.yaml
+++ b/kubernetes/apps/external-endpoints/unifi/endpointslice.yaml
@@ -1,0 +1,16 @@
+# Binds to service.yaml via the kubernetes.io/service-name label — that's
+# the only link, the EndpointSlice's own name doesn't matter.
+apiVersion: discovery.k8s.io/v1
+kind: EndpointSlice
+metadata:
+  name: unifi
+  labels:
+    kubernetes.io/service-name: unifi
+addressType: IPv4
+ports:
+  - name: https
+    protocol: TCP
+    port: 8443
+endpoints:
+  - addresses:
+      - 10.20.0.1

--- a/kubernetes/apps/external-endpoints/unifi/httproute.yaml
+++ b/kubernetes/apps/external-endpoints/unifi/httproute.yaml
@@ -1,0 +1,21 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: unifi
+  annotations:
+    gethomepage.dev/enabled: "true"
+    gethomepage.dev/name: "Unifi"
+    gethomepage.dev/description: "Network controller"
+    gethomepage.dev/group: "Network"
+    gethomepage.dev/icon: "unifi.png"
+spec:
+  parentRefs:
+    - name: ${gatewayName}
+      namespace: gateway
+      sectionName: https
+  hostnames:
+    - "unifi.${domain}"
+  rules:
+    - backendRefs:
+        - name: unifi
+          port: 8443

--- a/kubernetes/apps/external-endpoints/unifi/kustomization.yaml
+++ b/kubernetes/apps/external-endpoints/unifi/kustomization.yaml
@@ -1,0 +1,26 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - service.yaml
+  - endpointslice.yaml
+  - configmap-ca.yaml
+  - httproute.yaml
+
+components:
+  - ../_components/backend-tls
+
+# Wires the generic backend-tls component to this instance's Service/ConfigMap.
+patches:
+  - target:
+      kind: BackendTLSPolicy
+    patch: |-
+      - op: replace
+        path: /spec/targetRefs/0/name
+        value: unifi
+      - op: replace
+        path: /spec/validation/caCertificateRefs/0/name
+        value: unifi-ca
+      - op: replace
+        path: /spec/validation/hostname
+        value: unifi

--- a/kubernetes/apps/external-endpoints/unifi/service.yaml
+++ b/kubernetes/apps/external-endpoints/unifi/service.yaml
@@ -1,0 +1,12 @@
+# No selector: Kubernetes leaves endpoints alone, endpointslice.yaml
+# supplies them by hand ("Service without selector" pattern). Port matches
+# Unifi's controller UI, which is HTTPS-only — see backendtlspolicy.yaml.
+apiVersion: v1
+kind: Service
+metadata:
+  name: unifi
+spec:
+  ports:
+    - port: 8443
+      protocol: TCP
+      name: https

--- a/kubernetes/apps/pihole/overlays/orion/kustomization.yaml
+++ b/kubernetes/apps/pihole/overlays/orion/kustomization.yaml
@@ -10,3 +10,11 @@ resources:
 
 components:
   - ../../../webapp/components/httproute
+
+# gethomepage.dev discovery for the homepage dashboard; component's
+# HTTPRoute is generic and takes no annotations of its own.
+patches:
+  - path: patches/httproute-add-homepage-annotations.yaml
+    target:
+      kind: HTTPRoute
+      name: route

--- a/kubernetes/apps/pihole/overlays/orion/patches/httproute-add-homepage-annotations.yaml
+++ b/kubernetes/apps/pihole/overlays/orion/patches/httproute-add-homepage-annotations.yaml
@@ -1,0 +1,10 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: route
+  annotations:
+    gethomepage.dev/enabled: "true"
+    gethomepage.dev/name: "Pi-hole"
+    gethomepage.dev/description: "DNS / ad-block"
+    gethomepage.dev/group: "Network"
+    gethomepage.dev/icon: "pi-hole.png"

--- a/kubernetes/clusters/orion/external-endpoints.yaml
+++ b/kubernetes/clusters/orion/external-endpoints.yaml
@@ -1,0 +1,23 @@
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: external-endpoints
+  namespace: flux-system
+spec:
+  dependsOn:
+    - name: cilium
+    - name: gateway
+    - name: cluster-settings
+  interval: 1h
+  retryInterval: 1m
+  timeout: 5m
+  prune: true
+  wait: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+  path: ./kubernetes/apps/external-endpoints
+  postBuild:
+    substituteFrom:
+      - kind: ConfigMap
+        name: cluster-settings

--- a/kubernetes/clusters/orion/homepage.yaml
+++ b/kubernetes/clusters/orion/homepage.yaml
@@ -1,0 +1,21 @@
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: homepage
+  namespace: flux-system
+spec:
+  dependsOn:
+    - name: cluster-settings
+  interval: 1h
+  retryInterval: 1m
+  timeout: 5m
+  prune: true
+  wait: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+  path: ./kubernetes/infrastructure/homepage
+  postBuild:
+    substituteFrom:
+      - kind: ConfigMap
+        name: cluster-settings

--- a/kubernetes/infrastructure/README.md
+++ b/kubernetes/infrastructure/README.md
@@ -10,6 +10,7 @@ Shared HelmRelease and Kustomize building blocks consumed by any cluster. Each c
 | [cert-manager](cert-manager/README.md) | TLS certificate issuance (Let's Encrypt via Cloudflare DNS) | `cert-manager` |
 | [vkms](vkms/README.md) | VictoriaMetrics observability stack (Grafana, vmagent, vmalert, vmsingle, Alertmanager) | `monitoring` |
 | [headlamp](headlamp/README.md) | Cluster dashboard (workloads, CRDs, logs, exec), read-only RBAC | `headlamp` |
+| [homepage](homepage/README.md) | Link dashboard, auto-discovers HTTPRoutes via annotations | `homepage` |
 | rook-ceph-operator | Ceph operator | `rook-ceph` |
 | rook-ceph-cluster | Ceph cluster (default block storage) | `rook-ceph` |
 | gateway-api | Gateway API CRDs | `gateway-system` |

--- a/kubernetes/infrastructure/gateway/ceph-dashboard-httproute.yaml
+++ b/kubernetes/infrastructure/gateway/ceph-dashboard-httproute.yaml
@@ -3,6 +3,12 @@ kind: HTTPRoute
 metadata:
   name: ceph-dashboard
   namespace: gateway
+  annotations:
+    gethomepage.dev/enabled: "true"
+    gethomepage.dev/name: "Ceph"
+    gethomepage.dev/description: "Storage cluster health"
+    gethomepage.dev/group: "Cluster"
+    gethomepage.dev/icon: "ceph.png"
 spec:
   parentRefs:
     - name: orion

--- a/kubernetes/infrastructure/gateway/homepage-httproute.yaml
+++ b/kubernetes/infrastructure/gateway/homepage-httproute.yaml
@@ -1,26 +1,26 @@
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
-  name: headlamp
-  namespace: headlamp
+  name: homepage
+  namespace: homepage
   annotations:
     gethomepage.dev/enabled: "true"
-    gethomepage.dev/name: "Headlamp"
-    gethomepage.dev/description: "Cluster dashboard"
+    gethomepage.dev/name: "Homepage"
+    gethomepage.dev/description: "This dashboard"
     gethomepage.dev/group: "Cluster"
-    gethomepage.dev/icon: "kubernetes.png"
+    gethomepage.dev/icon: "homepage.png"
 spec:
   parentRefs:
     - name: orion
       namespace: gateway
       sectionName: https
   hostnames:
-    - "headlamp.${domain}"
+    - "homepage.${domain}"
   rules:
     - matches:
         - path:
             type: PathPrefix
             value: /
       backendRefs:
-        - name: headlamp
-          port: 80
+        - name: homepage
+          port: 3000

--- a/kubernetes/infrastructure/gateway/hubble-httproute.yaml
+++ b/kubernetes/infrastructure/gateway/hubble-httproute.yaml
@@ -3,6 +3,12 @@ kind: HTTPRoute
 metadata:
   name: hubble-ui
   namespace: cilium
+  annotations:
+    gethomepage.dev/enabled: "true"
+    gethomepage.dev/name: "Hubble"
+    gethomepage.dev/description: "Cilium network observability"
+    gethomepage.dev/group: "Cluster"
+    gethomepage.dev/icon: "cilium.png"
 spec:
   parentRefs:
     - name: orion

--- a/kubernetes/infrastructure/gateway/kustomization.yaml
+++ b/kubernetes/infrastructure/gateway/kustomization.yaml
@@ -7,5 +7,6 @@ resources:
   - hubble-httproute.yaml
   - ceph-dashboard-httproute.yaml
   - headlamp-httproute.yaml
+  - homepage-httproute.yaml
   - http-redirect.yaml
   - reference-grant.yaml

--- a/kubernetes/infrastructure/homepage/README.md
+++ b/kubernetes/infrastructure/homepage/README.md
@@ -1,0 +1,38 @@
+# homepage
+
+Link dashboard ([gethomepage/homepage](https://gethomepage.dev)) for orion —
+one page linking out to every service instead of bookmarking each host.
+
+## Configuration
+
+- **Chart:** `homepage` from the `jameswynn/helm-charts` repo (pinned in
+  `release.yaml`) — wraps the upstream `ghcr.io/gethomepage/homepage` image.
+- **Namespace:** `homepage`
+- **Values source:** ConfigMap (`values.yaml` via kustomize `configMapGenerator`)
+
+Services aren't hand-listed here. `config.kubernetes.mode: cluster` +
+`gateway: true` turns on live discovery of `HTTPRoute` resources cluster-wide;
+each route opts in via `gethomepage.dev/*` annotations (see
+`infrastructure/gateway/*-httproute.yaml` and `apps/pihole/overlays/orion`).
+Add the same annotations to any new HTTPRoute to get it listed for free.
+
+`enableRbac: true` grants the chart's own `ClusterRole` — read-only
+get/list on namespaces/pods/nodes/ingresses/httproutes/gateways, nothing
+that can mutate cluster state.
+
+## Dependencies
+
+Cilium (Gateway API) must be running. No secrets, no decryption needed.
+`HOMEPAGE_ALLOWED_HOSTS` is substituted from `cluster-settings` at
+reconcile time (`clusters/orion/homepage.yaml`), same as `${domain}`
+elsewhere.
+
+## Ingress / Endpoints
+
+`homepage.${domain}` — HTTPRoute lives in `infrastructure/gateway/`
+(same-namespace backend, mirrors `headlamp`).
+
+## Access
+
+No login — the dashboard is just outbound links plus read-only cluster
+widgets, nothing sensitive to gate.

--- a/kubernetes/infrastructure/homepage/kustomization.yaml
+++ b/kubernetes/infrastructure/homepage/kustomization.yaml
@@ -1,0 +1,15 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: homepage
+resources:
+  - namespace.yaml
+  - repository.yaml
+  - release.yaml
+
+configMapGenerator:
+- name: homepage-helm-chart-values
+  files:
+  - values.yaml
+
+configurations:
+  - kustomizeconfig.yaml

--- a/kubernetes/infrastructure/homepage/kustomizeconfig.yaml
+++ b/kubernetes/infrastructure/homepage/kustomizeconfig.yaml
@@ -1,0 +1,6 @@
+nameReference:
+- kind: ConfigMap
+  version: v1
+  fieldSpecs:
+  - path: spec/valuesFrom/name
+    kind: HelmRelease

--- a/kubernetes/infrastructure/homepage/namespace.yaml
+++ b/kubernetes/infrastructure/homepage/namespace.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: homepage
+  labels:
+    gateway.networking.k8s.io/access: "true"

--- a/kubernetes/infrastructure/homepage/release.yaml
+++ b/kubernetes/infrastructure/homepage/release.yaml
@@ -1,0 +1,25 @@
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: homepage
+  namespace: homepage
+spec:
+  interval: 1h
+  chart:
+    spec:
+      chart: homepage
+      version: "2.1.0"
+      sourceRef:
+        kind: HelmRepository
+        name: homepage
+      interval: 1h
+  install:
+    remediation:
+      retries: 3
+  upgrade:
+    remediation:
+      retries: 3
+  valuesFrom:
+    - kind: ConfigMap
+      name: homepage-helm-chart-values
+      valuesKey: values.yaml

--- a/kubernetes/infrastructure/homepage/repository.yaml
+++ b/kubernetes/infrastructure/homepage/repository.yaml
@@ -1,0 +1,8 @@
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: HelmRepository
+metadata:
+  name: homepage
+  namespace: homepage
+spec:
+  url: https://jameswynn.github.io/helm-charts
+  interval: 1h

--- a/kubernetes/infrastructure/homepage/values.yaml
+++ b/kubernetes/infrastructure/homepage/values.yaml
@@ -1,0 +1,37 @@
+# Read-only cluster discovery: lets Homepage list services from HTTPRoute
+# annotations instead of a hand-maintained link list. ClusterRole (chart's
+# own, via enableRbac) only grants get/list on namespaces/pods/nodes/
+# ingresses/httproutes/gateways — no write access, matching the
+# "changes go through git+Flux" convention for this repo.
+enableRbac: true
+
+serviceAccount:
+  create: true
+
+env:
+  - name: HOMEPAGE_ALLOWED_HOSTS
+    value: "homepage.${domain}"
+
+config:
+  kubernetes:
+    mode: cluster
+    gateway: true
+
+  # Populated via gethomepage.dev/* annotations on each HTTPRoute instead of
+  # a static list here — see infrastructure/gateway/*-httproute.yaml.
+  services:
+  bookmarks:
+
+  widgets:
+    - resources:
+        backend: resources
+        expanded: true
+        cpu: true
+        memory: true
+    - search:
+        provider: duckduckgo
+        target: _blank
+
+  settingsString: |
+    title: orion
+    headerStyle: boxed


### PR DESCRIPTION
## Summary

Routes cluster-external hosts (LAN devices, appliances — anything not running as a Pod) through the orion Gateway with a real cert, using the standard Kubernetes "Service without selector" pattern: a Service with no selector paired with a hand-written EndpointSlice pointing at the external IP. TLS comes from the Gateway's existing wildcard cert. Nothing Cilium-specific about the mechanism beyond Cilium being the Gateway API implementation — it's plain Kubernetes.

All forwarded hosts share one namespace (`external-endpoints`) and one Flux Kustomization, since none of this owns Pods/PVCs/secrets worth isolating. A `_template/` dir + README make adding a new one a copy-and-`sed` job.

## Entries added

| Host | IP | Notes |
|---|---|---|
| opensprinkler | 10.30.0.249 | plain HTTP |
| slzb-06 | 10.50.0.150 | SMLIGHT Zigbee-to-Ethernet coordinator for Home Assistant, plain HTTP |
| truenas | 10.50.0.212 | plain HTTP |
| unifi | 10.20.0.1:8443 | HTTPS-only — Gateway re-encrypts to it via a new reusable `_components/backend-tls` component (BackendTLSPolicy), validated against the device's own self-signed cert (pulled into a ConfigMap) |
| neurio | 10.30.0.217 | PWRview/Neurio power monitor, plain HTTP |

All five get Homepage dashboard tiles via `gethomepage.dev` HTTPRoute annotations.

## Design notes

- Considered a kustomize base+overlays layout instead of flat per-instance directories; kept flat since the shared boilerplate is too small to justify the JSON6902-patch indirection (worked comparison available on request).
- The `backend-tls` component was extracted with Unifi as the sole current consumer, in anticipation of other HTTPS-only appliances (BMCs, etc.) — documented in the README.

## Verification

- `task gen:validate` — clean (yamllint, kubeconform, kube-linter)
- `task test:build` — 17/17 Kustomizations build, no unresolved `${...}` substitutions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for exposing external services through HTTPS routes and manually managed endpoints.
  - Added dashboard access for Neurio, OpenSprinkler, SLZB-06, TrueNAS, and UniFi.
  - Added the Homepage dashboard with Kubernetes discovery, service widgets, search, and read-only access.
  - Added Homepage metadata for infrastructure services, including Pi-hole, Ceph, Headlamp, Hubble, and Homepage itself.
  - Added HTTPS certificate validation for UniFi connections.

- **Documentation**
  - Documented external endpoint setup, HTTPS configuration, Homepage deployment, discovery, and access requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->