### PR TITLE
fix: httproute component default port should match webapp/base

### DIFF
--- a/kubernetes/apps/home-automation/zigbee2mqtt/kustomization.yaml
+++ b/kubernetes/apps/home-automation/zigbee2mqtt/kustomization.yaml
@@ -22,14 +22,7 @@ images:
     newName: koenkk/zigbee2mqtt
     newTag: "1.38.0"
 
-# httproute component hardcodes backendRefs.port: 80 (matches the pihole-
-# style convention of remapping the Service itself to 80); zigbee2mqtt's
-# frontend stays on 8080, so the Service needs the same remap.
 patches:
-  - target:
-      kind: Service
-      name: svc
-    path: patches/svc-remap-port-80.yaml
   - target:
       kind: HTTPRoute
       name: route

--- a/kubernetes/apps/home-automation/zigbee2mqtt/patches/svc-remap-port-80.yaml
+++ b/kubernetes/apps/home-automation/zigbee2mqtt/patches/svc-remap-port-80.yaml
@@ -1,3 +1,0 @@
-- op: replace
-  path: /spec/ports/0/port
-  value: 80

--- a/kubernetes/apps/pihole/overlays/orion/kustomization.yaml
+++ b/kubernetes/apps/pihole/overlays/orion/kustomization.yaml
@@ -18,3 +18,11 @@ patches:
     target:
       kind: HTTPRoute
       name: route
+  # webapp/base's Service defaults to 8080 (what the httproute component
+  # assumes); pihole's own container really listens on 80, and
+  # patches/svc-update-ports.yaml already moved the Service there — this
+  # keeps the HTTPRoute's backend port in sync.
+  - path: patches/httproute-update-port.yaml
+    target:
+      kind: HTTPRoute
+      name: route

--- a/kubernetes/apps/pihole/overlays/orion/patches/httproute-update-port.yaml
+++ b/kubernetes/apps/pihole/overlays/orion/patches/httproute-update-port.yaml
@@ -1,0 +1,3 @@
+- op: replace
+  path: /spec/rules/0/backendRefs/0/port
+  value: 80

--- a/kubernetes/apps/webapp/README.md
+++ b/kubernetes/apps/webapp/README.md
@@ -68,6 +68,13 @@ Default on orion. Adds a Gateway API `HTTPRoute` attached to `${gatewayName}` (n
 | `domain` | `cluster-settings` ConfigMap | `orion.norseamerican.com` |
 | `gatewayName` | `cluster-settings` ConfigMap | `orion` |
 
+`backendRefs.port` defaults to `8080` — matching `webapp/base`'s Service — because
+Gateway API's `HTTPRoute` only accepts a numeric port (unlike `ingress`'s
+`port: {name: http}`, there's no name-based backend ref to fall back on). If an
+overlay repatches the Service to a different port (pihole -> `80`, since its
+container really listens there), patch the HTTPRoute's `backendRefs[0].port` to
+match — see `apps/pihole/overlays/orion/patches/httproute-update-port.yaml`.
+
 ### pvc
 
 Adds a `ReadWriteOnce` PVC named `data` and mounts it at `/data` on the `deploy` container. A `nameReference` transformer rewires the volume's `claimName` when `namePrefix` is applied. The volumeMount patch targets `spec.template.spec.containers/0` — the first container in the Deployment.

--- a/kubernetes/apps/webapp/components/httproute/httproute.yaml
+++ b/kubernetes/apps/webapp/components/httproute/httproute.yaml
@@ -12,4 +12,7 @@ spec:
   rules:
     - backendRefs:
         - name: svc
-          port: 80
+          # Matches webapp/base's Service port. Consumers that repatch the
+          # Service to a different port (e.g. pihole -> 80) must patch this
+          # HTTPRoute's port to match — see pihole/overlays/orion for the example.
+          port: 8080


### PR DESCRIPTION
Follow-up to #85, which merged before this landed.

\`webapp/components/httproute\` hardcoded \`backendRefs.port: 80\`, but \`webapp/base\`'s Service actually defaults to \`8080\` — the shared component's assumption didn't match its own base. \`pihole\` (the only prior consumer) never hit this because it repatches its Service to \`80\` anyway for real container reasons; every other consumer — \`zigbee2mqtt\` today, anything \`task gen:new-app\` scaffolds tomorrow — inherited a mismatch it had to patch around for no good reason.

## What changed
- \`webapp/components/httproute/httproute.yaml\`: \`port: 80\` → \`port: 8080\`, matching \`webapp/base\`'s real default.
- Moved the "80" special-case onto \`pihole/overlays/orion\` (the actual deviator) via a new \`patches/httproute-update-port.yaml\`.
- Removed \`zigbee2mqtt\`'s now-unnecessary \`svc-remap-port-80.yaml\` patch — the Service and HTTPRoute both default to 8080 and just match.
- Documented the port assumption in \`webapp/README.md\`, including why a named port (\`port: {name: http}\`, like the \`ingress\` component already does) isn't possible — Gateway API's \`HTTPRoute.backendRefs[].port\` is a strict integer in the CRD schema, unlike \`Ingress.backend.service.port\`, which accepts a name.

## Verification
- \`task gen:validate\` — clean.
- \`task test:build\` — 18/18, no unresolved \`\${...}\` vars.
- Confirmed by hand: \`zigbee2mqtt\` now renders unpatched with Service port 8080 / HTTPRoute backend port 8080 (matching); \`pihole\` still renders Service port 80 / HTTPRoute backend port 80 (matching, via its new patch) — i.e. this doesn't regress the one app already relying on the old hardcoded value.

🤖 Generated with [Claude Code](https://claude.com/claude-code)