### PR TITLE
fix: register ceph-csi Driver/OperatorConfig CRs for rook-ceph

### DIFF
--- a/kubernetes/infrastructure/rook-ceph-cluster/csi-driver.yaml
+++ b/kubernetes/infrastructure/rook-ceph-cluster/csi-driver.yaml
@@ -1,0 +1,70 @@
+# The rook-ceph chart's csi.installCsiOperator: true
+# (../rook-ceph-operator/release.yaml) only installs the ceph-csi-operator
+# controller, its CRDs, and RBAC — it does NOT create the
+# OperatorConfig/Driver CRs that actually make it deploy the CSI
+# provisioner/node plugin pods. Rook's own upstream example
+# (deploy/examples/operator.yaml in rook/rook) ships these as separate
+# "admin-managed" resources for exactly that reason. Without them, PVCs
+# using rook-ceph-block sit Pending forever ("waiting for a volume to be
+# created by rook-ceph.rbd.csi.ceph.com") since no CSIDriver is registered.
+#
+# Lives here (not rook-ceph-operator/) so it applies after the operator's
+# HelmRelease is Ready and the Driver/OperatorConfig CRDs actually exist —
+# rook-ceph-cluster's Flux Kustomization already dependsOn: rook-ceph-operator.
+#
+# Image tags mirror the rook-ceph-operator chart's own csi.* defaults
+# (helm show values rook-release/rook-ceph --version <chart version in
+# ../rook-ceph-operator/release.yaml>) — re-check these when that chart
+# version bumps.
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: rook-csi-operator-image-set-configmap
+  namespace: rook-ceph
+data:
+  provisioner: "registry.k8s.io/sig-storage/csi-provisioner:v6.2.0"
+  attacher: "registry.k8s.io/sig-storage/csi-attacher:v4.12.0"
+  resizer: "registry.k8s.io/sig-storage/csi-resizer:v2.1.0"
+  snapshotter: "registry.k8s.io/sig-storage/csi-snapshotter:v8.5.0"
+  registrar: "registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.17.0"
+  plugin: "quay.io/cephcsi/cephcsi:v3.17.0"
+  addons: "quay.io/csiaddons/k8s-sidecar:v0.14.0"
+---
+apiVersion: csi.ceph.io/v1
+kind: OperatorConfig
+metadata:
+  name: ceph-csi-operator-config
+  namespace: rook-ceph
+spec:
+  driverSpecDefaults:
+    log:
+      verbosity: 0
+    imageSet:
+      name: rook-csi-operator-image-set-configmap
+    enableMetadata: true
+    generateOMapInfo: false
+    fsGroupPolicy: File
+    deployCsiAddons: false
+    cephFsClientType: kernel
+    nodePlugin:
+      priorityClassName: "system-node-critical"
+      kubeletDirPath: /var/lib/kubelet
+      enableSeLinuxHostMount: false
+    controllerPlugin:
+      priorityClassName: "system-cluster-critical"
+      deploymentStrategy:
+        type: Recreate
+---
+# RBD only — orion's only StorageClass (rook-ceph-block) is RBD-backed;
+# no CephFS/NFS pools exist yet. Add those Driver CRs here if that changes.
+apiVersion: csi.ceph.io/v1
+kind: Driver
+metadata:
+  name: rook-ceph.rbd.csi.ceph.com # must match the StorageClass's provisioner
+  namespace: rook-ceph
+spec:
+  fsGroupPolicy: File
+  nodePlugin:
+    updateStrategy:
+      type: RollingUpdate
+  controllerPlugin: {}

--- a/kubernetes/infrastructure/rook-ceph-cluster/kustomization.yaml
+++ b/kubernetes/infrastructure/rook-ceph-cluster/kustomization.yaml
@@ -4,3 +4,4 @@ resources:
   - cluster.yaml
   - blockpool.yaml
   - reference-grant.yaml
+  - csi-driver.yaml


### PR DESCRIPTION
## The bug

zigbee2mqtt/mosquitto's PVCs (from #85) sit `Pending` forever:

\`\`\`
Waiting for a volume to be created either by the external provisioner
'rook-ceph.rbd.csi.ceph.com' or manually by the system administrator.
\`\`\`

This blocks the pods (no volume → no schedule → Service has no endpoints → Gateway shows "no healthy upstream"), but the root cause is **cluster-wide, not app-specific**: these are the first PVCs ever created on orion. Mons/OSDs have been healthy for 12+ days; nothing had exercised dynamic provisioning until now, so this has silently been broken the whole time.

## Root cause

\`rook-ceph-operator\`'s HelmRelease sets \`csi.installCsiOperator: true\` (chart \`1.20.2\`'s default). That installs the \`ceph-csi-operator\` controller-manager, its CRDs, and RBAC — confirmed \`Running\` — but does **not** create the \`OperatorConfig\`/\`Driver\` custom resources that actually tell it to deploy the CSI provisioner/node plugin pods:

- \`kubectl get csidriver\` → empty
- \`kubectl get drivers.csi.ceph.io\` → empty
- \`ceph-csi-controller-manager\` pod: \`Running\`, but idle — nothing to reconcile

Traced this against \`rook/rook\`'s own \`deploy/examples/operator.yaml\` (tag \`v1.20.2\`): upstream documents these as resources "managed by the admin" — the Helm chart intentionally doesn't render them, they're expected to be applied separately. This repo never added them because storage was never exercised before #85.

## Fix

\`kubernetes/infrastructure/rook-ceph-cluster/csi-driver.yaml\`:
- image-set \`ConfigMap\` (pins CSI sidecar versions, mirrors the chart's own \`csi.*\` defaults)
- \`OperatorConfig\` (\`driverSpecDefaults\`, copied from upstream's example)
- one \`Driver\` CR for RBD — name matches the StorageClass's provisioner (\`rook-ceph.rbd.csi.ceph.com\`). No CephFS/NFS pools exist on orion yet, so only RBD is registered; easy to extend later.

Placed in \`rook-ceph-cluster/\` rather than \`rook-ceph-operator/\` on purpose: \`rook-ceph-cluster\`'s Flux Kustomization already \`dependsOn: rook-ceph-operator\` (with \`wait: true\`), which guarantees the \`Driver\`/\`OperatorConfig\` CRDs actually exist by the time this applies — putting it beside the HelmRelease itself would race the CRD install.

## Verification

- \`task gen:validate\` / \`task test:build\` — clean.
- Diagnosed against the live orion cluster via **read-only** \`kubectl\` only (per repo policy) — no direct cluster changes; everything here goes through this PR + Flux.
- Not yet re-verified against the live cluster post-merge (would need another read-only check after Flux reconciles) — worth confirming \`kubectl get csidriver\` shows \`rook-ceph.rbd.csi.ceph.com\` and the #85 PVCs bind afterward.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Kubernetes configuration for the Rook Ceph CSI driver.
  * Enabled RBD-based storage provisioning through the `rook-ceph-block` StorageClass.
  * Added default CSI settings and controller/node plugin configuration.
  * Defined the CSI sidecar and Ceph CSI image versions.
  * Included the CSI resources in the infrastructure deployment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->