### PR TITLE
fix: add missing RBD CSI plugin ServiceAccounts/RBAC

### DIFF
--- a/kubernetes/infrastructure/rook-ceph-cluster/csi-rbd-rbac.yaml
+++ b/kubernetes/infrastructure/rook-ceph-cluster/csi-rbd-rbac.yaml
@@ -1,0 +1,473 @@
+# ServiceAccounts + RBAC for the RBD CSI plugin pods that
+# csi-driver.yaml's Driver CR causes ceph-csi-operator to spin up.
+#
+# Neither the rook-ceph chart nor its ceph-csi-operator subchart create
+# these — confirmed by the driver-controller reconcile actually failing
+# without them: "serviceaccount rook-ceph/rbd-nodeplugin-sa not found".
+# They come from ceph-csi-operator's own deploy/multifile/csi-rbac.yaml
+# (https://github.com/ceph/ceph-csi-operator/blob/v1.0.4/deploy/multifile/csi-rbac.yaml,
+# pinned to the ceph-csi-operator version installed by the rook-ceph chart
+# in ../rook-ceph-operator/release.yaml) — extracted to RBD-only (no
+# CephFS/NFS/NVMe-oF pools exist here), renamed from
+# ceph-csi-operator-rbd-* to rbd-* (this cluster's ceph-csi-operator runs
+# with an empty CSI_SERVICE_ACCOUNT_PREFIX, so that's the name it actually
+# looks up), and retargeted from namespace ceph-csi-operator-system to
+# rook-ceph (where this chart actually deploys it).
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: rbd-ctrlplugin-sa
+  namespace: rook-ceph
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: rbd-nodeplugin-sa
+  namespace: rook-ceph
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: rbd-ctrlplugin-r
+  namespace: rook-ceph
+rules:
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - get
+  - watch
+  - list
+  - delete
+  - update
+  - create
+- apiGroups:
+  - csiaddons.openshift.io
+  resources:
+  - csiaddonsnodes
+  verbs:
+  - get
+  - watch
+  - list
+  - create
+  - update
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - get
+- apiGroups:
+  - apps
+  resources:
+  - replicasets
+  verbs:
+  - get
+- apiGroups:
+  - apps
+  resources:
+  - deployments/finalizers
+  - daemonsets/finalizers
+  verbs:
+  - update
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: rbd-nodeplugin-r
+  namespace: rook-ceph
+rules:
+- apiGroups:
+  - csiaddons.openshift.io
+  resources:
+  - csiaddonsnodes
+  verbs:
+  - get
+  - watch
+  - list
+  - create
+  - update
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - get
+- apiGroups:
+  - apps
+  resources:
+  - replicasets
+  verbs:
+  - get
+- apiGroups:
+  - apps
+  resources:
+  - deployments/finalizers
+  - daemonsets/finalizers
+  verbs:
+  - update
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: rbd-ctrlplugin-cr
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumes
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - delete
+  - patch
+  - update
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumeclaims
+  verbs:
+  - get
+  - list
+  - watch
+  - update
+- apiGroups:
+  - storage.k8s.io
+  resources:
+  - storageclasses
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - list
+  - watch
+  - create
+  - update
+  - patch
+- apiGroups:
+  - storage.k8s.io
+  resources:
+  - volumeattachments
+  verbs:
+  - get
+  - list
+  - watch
+  - patch
+- apiGroups:
+  - storage.k8s.io
+  resources:
+  - volumeattachments/status
+  verbs:
+  - patch
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - storage.k8s.io
+  resources:
+  - csinodes
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumeclaims/status
+  verbs:
+  - patch
+- apiGroups:
+  - snapshot.storage.k8s.io
+  resources:
+  - volumesnapshots
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - snapshot.storage.k8s.io
+  resources:
+  - volumesnapshotclasses
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - snapshot.storage.k8s.io
+  resources:
+  - volumesnapshotcontents
+  verbs:
+  - get
+  - list
+  - watch
+  - patch
+  - update
+- apiGroups:
+  - snapshot.storage.k8s.io
+  resources:
+  - volumesnapshotcontents/status
+  verbs:
+  - update
+  - patch
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - get
+- apiGroups:
+  - ""
+  resources:
+  - serviceaccounts
+  verbs:
+  - get
+- apiGroups:
+  - ""
+  resources:
+  - serviceaccounts/token
+  verbs:
+  - create
+- apiGroups:
+  - groupsnapshot.storage.k8s.io
+  resources:
+  - volumegroupsnapshotclasses
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - groupsnapshot.storage.k8s.io
+  resources:
+  - volumegroupsnapshotcontents
+  verbs:
+  - get
+  - list
+  - watch
+  - update
+  - patch
+- apiGroups:
+  - groupsnapshot.storage.k8s.io
+  resources:
+  - volumegroupsnapshotcontents/status
+  verbs:
+  - update
+  - patch
+- apiGroups:
+  - groupsnapshot.storage.openshift.io
+  resources:
+  - volumegroupsnapshotclasses
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - groupsnapshot.storage.openshift.io
+  resources:
+  - volumegroupsnapshotcontents
+  verbs:
+  - get
+  - list
+  - watch
+  - update
+  - patch
+- apiGroups:
+  - groupsnapshot.storage.openshift.io
+  resources:
+  - volumegroupsnapshotcontents/status
+  verbs:
+  - update
+  - patch
+- apiGroups:
+  - replication.storage.openshift.io
+  resources:
+  - volumegroupreplicationcontents
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - replication.storage.openshift.io
+  resources:
+  - volumegroupreplicationclasses
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - authentication.k8s.io
+  resources:
+  - tokenreviews
+  verbs:
+  - create
+- apiGroups:
+  - authorization.k8s.io
+  resources:
+  - subjectaccessreviews
+  verbs:
+  - create
+- apiGroups:
+  - cbt.storage.k8s.io
+  resources:
+  - snapshotmetadataservices
+  verbs:
+  - get
+  - list
+- apiGroups:
+  - storage.k8s.io
+  resources:
+  - volumeattributesclasses
+  verbs:
+  - get
+  - list
+  - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: rbd-nodeplugin-cr
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumes
+  verbs:
+  - get
+  - list
+- apiGroups:
+  - storage.k8s.io
+  resources:
+  - volumeattachments
+  verbs:
+  - get
+  - list
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - get
+- apiGroups:
+  - ""
+  resources:
+  - serviceaccounts
+  verbs:
+  - get
+- apiGroups:
+  - ""
+  resources:
+  - serviceaccounts/token
+  verbs:
+  - create
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - get
+- apiGroups:
+  - authentication.k8s.io
+  resources:
+  - tokenreviews
+  verbs:
+  - create
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - list
+  - watch
+  - create
+  - update
+  - patch
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumeclaims
+  verbs:
+  - get
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: rbd-ctrlplugin-rb
+  namespace: rook-ceph
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: rbd-ctrlplugin-r
+subjects:
+- kind: ServiceAccount
+  name: rbd-ctrlplugin-sa
+  namespace: rook-ceph
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: rbd-nodeplugin-rb
+  namespace: rook-ceph
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: rbd-nodeplugin-r
+subjects:
+- kind: ServiceAccount
+  name: rbd-nodeplugin-sa
+  namespace: rook-ceph
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: rbd-ctrlplugin-crb
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: rbd-ctrlplugin-cr
+subjects:
+- kind: ServiceAccount
+  name: rbd-ctrlplugin-sa
+  namespace: rook-ceph
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: rbd-nodeplugin-crb
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: rbd-nodeplugin-cr
+subjects:
+- kind: ServiceAccount
+  name: rbd-nodeplugin-sa
+  namespace: rook-ceph

--- a/kubernetes/infrastructure/rook-ceph-cluster/kustomization.yaml
+++ b/kubernetes/infrastructure/rook-ceph-cluster/kustomization.yaml
@@ -5,3 +5,4 @@ resources:
   - blockpool.yaml
   - reference-grant.yaml
   - csi-driver.yaml
+  - csi-rbd-rbac.yaml


### PR DESCRIPTION
Follow-up to #88, one layer deeper.

## Status check on #88

Confirmed live (read-only \`kubectl\`, no direct changes): the \`Driver\` CR from #88 got picked up correctly.

\`\`\`
$ kubectl get csidriver
NAME                         ATTACHREQUIRED   ...
rook-ceph.rbd.csi.ceph.com   true             ...
\`\`\`

\`ceph-csi-controller-manager\` logs show it actively reconciling and creating a \`Deployment\` (\`...-ctrlplugin\`) and \`DaemonSet\` (\`...-nodeplugin\`) for the driver. But zero pods ever started:

\`\`\`
Warning  FailedCreate  daemonset-controller  Error creating: pods
"rook-ceph.rbd.csi.ceph.com-nodeplugin-" is forbidden: error looking up
service account rook-ceph/rbd-nodeplugin-sa: serviceaccount
"rbd-nodeplugin-sa" not found
\`\`\`

## Root cause

Same gap as #88, one layer deeper: neither the \`rook-ceph\` chart nor its \`ceph-csi-operator\` subchart create the \`ServiceAccount\`s/\`Role\`s/\`ClusterRole\`s the generated pod specs reference — those are expected to come from ceph-csi-operator's own separate RBAC manifest, same "admin-managed" pattern as the \`Driver\`/\`OperatorConfig\` CRs.

Traced the exact expected names via \`ceph-csi-operator\`'s source (\`internal/controller/driver_controller.go\`): \`{CSI_SERVICE_ACCOUNT_PREFIX}{driverType}-{ctrlplugin,nodeplugin}-sa\`. Our \`ceph-csi-controller-manager\` runs with an empty prefix (\`csiServiceAccountPrefix: ""\` in the chart values), giving \`rbd-nodeplugin-sa\`/\`rbd-ctrlplugin-sa\` — matches the error exactly.

## Fix

\`kubernetes/infrastructure/rook-ceph-cluster/csi-rbd-rbac.yaml\`: extracted from ceph-csi-operator's own [\`deploy/multifile/csi-rbac.yaml\`](https://github.com/ceph/ceph-csi-operator/blob/v1.0.4/deploy/multifile/csi-rbac.yaml) (pinned to \`v1.0.4\`, the version the \`rook-ceph\` chart installs per \`release.yaml\`), filtered to RBD only (no CephFS/NFS/NVMe-oF pools exist on orion), renamed \`ceph-csi-operator-rbd-*\` → \`rbd-*\` to match the actual expected names, and retargeted from namespace \`ceph-csi-operator-system\` → \`rook-ceph\` (where this chart actually deploys it).

10 resources: 2 \`ServiceAccount\`, 2 \`Role\`, 2 \`ClusterRole\`, 2 \`RoleBinding\`, 2 \`ClusterRoleBinding\` — ctrlplugin + nodeplugin pairs.

## Verification

- \`task gen:validate\` / \`task test:build\` — clean.
- All 10 resources individually schema-valid via \`kubeconform\` before committing.
- Diagnosed via read-only \`kubectl\` against the live cluster only, same policy as #88 — no direct changes applied; this is the fix.
- Not yet re-verified against the live cluster post-merge — once this reconciles, worth checking \`kubectl get pods -n rook-ceph | grep rbd\` shows the ctrlplugin/nodeplugin pods \`Running\`, and that the #85 PVCs finally bind.

🤖 Generated with [Claude Code](https://claude.com/claude-code)