### PR TITLE
fix: bump zigbee2mqtt CPU limit, webapp/base's 10m throttles it badly

### DIFF
--- a/kubernetes/apps/home-automation/zigbee2mqtt/kustomization.yaml
+++ b/kubernetes/apps/home-automation/zigbee2mqtt/kustomization.yaml
@@ -31,3 +31,12 @@ patches:
       kind: Deployment
       name: deploy
     path: patches/deploy-add-config-init.yaml
+  # webapp/base defaults to cpu: 10m — fine for a static file server, not
+  # enough for a Node.js process doing zigbee-herdsman startup. Confirmed
+  # via cgroup cpu.stat on the live pod: >99% of periods throttled,
+  # ~15min of accumulated throttled time just to get through boot. The
+  # original (pre-webapp/base) standalone deployment had no limit at all.
+  - target:
+      kind: Deployment
+      name: deploy
+    path: patches/deploy-update-resources.yaml

--- a/kubernetes/apps/home-automation/zigbee2mqtt/patches/deploy-update-resources.yaml
+++ b/kubernetes/apps/home-automation/zigbee2mqtt/patches/deploy-update-resources.yaml
@@ -1,0 +1,9 @@
+- op: replace
+  path: /spec/template/spec/containers/0/resources
+  value:
+    limits:
+      cpu: 500m
+      memory: 500Mi
+    requests:
+      cpu: 100m
+      memory: 250Mi


### PR DESCRIPTION
Storage (#88) and CSI RBAC (#89) are both fixed and confirmed live — PVCs bound, pods scheduled and \`Running\`. But zigbee2mqtt was still effectively unusable.

## What I found

\`\`\`
$ kubectl logs -n home-automation deploy/zigbee2mqtt-deploy --timestamps
2026-08-07T19:31:27Z Using '/data' as data directory
2026-08-07T19:37:43Z [...] z2m: Logging to console
2026-08-07T19:37:47Z [...] z2m: Starting Zigbee2MQTT version 1.38.0
2026-08-07T19:37:48Z [...] z2m: Starting zigbee-herdsman (0.49.2)
2026-08-07T19:38:53Z [...] zh:zstack:znp: Opening TCP socket with 10.50.0.150:6638
\`\`\`

**Six minutes** between container start and the first real log line. TCP reachability to the SLZB-06 coordinator itself checks out fine (tested directly from inside the pod). The delay is CPU starvation:

\`\`\`
$ kubectl exec deploy/zigbee2mqtt-deploy -- cat /sys/fs/cgroup/cpu.stat
nr_periods 5026
nr_throttled 5018
throttled_usec 927422628   # ~927s throttled
\`\`\`

>99% of scheduling periods throttled, ~15 minutes of accumulated throttle time.

## Root cause

\`webapp/base\`'s default \`resources.limits.cpu: 10m\` is fine for a static file server; it's nowhere near enough for a Node.js process doing \`zigbee-herdsman\` startup. This is a **regression from my own \`webapp/base\` migration** — the original standalone \`zigbee2mqtt\` deployment (before that refactor) had no CPU limit at all, so it never ran under this constraint before.

## Fix

\`patches/deploy-update-resources.yaml\`: bumps the container's \`resources\` to \`limits.cpu: 500m\` (request \`100m\`), memory unchanged.

## Verification

- \`task gen:validate\` / \`task test:build\` — clean.
- Diagnosed via read-only \`kubectl\` only (\`kubectl exec ... cat /sys/fs/cgroup/cpu.stat\`; \`kubectl top\` unavailable, no metrics-server) — no direct cluster changes.
- Not yet re-verified against the live cluster post-merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)