### PR TITLE
feat: update zigbee2mqtt 1.38.0 -> 2.13.0 (latest stable)

### DIFF
--- a/kubernetes/apps/home-automation/README.md
+++ b/kubernetes/apps/home-automation/README.md
@@ -11,11 +11,12 @@ orion via `kubernetes/clusters/orion/home-automation.yaml`, namespace
 | `mosquitto/` | MQTT message broker. Standalone manifests, no HTTP surface — `webapp/base` doesn't buy anything here, same reasoning as `external-endpoints`. |
 | `zigbee2mqtt/` | Zigbee coordinator bridge → MQTT. Built on `../../webapp/base` + `httproute`/`pvc` components, frontend at `z2m.${domain}`. |
 
-`zigbee2mqtt/patches/`: `svc-remap-port-80.yaml` (the `httproute` component hardcodes
-`backendRefs.port: 80`, so the Service gets remapped to match — same convention
-`pihole` uses), `httproute-add-homepage-annotations.yaml`, and
+`zigbee2mqtt/patches/`: `httproute-add-homepage-annotations.yaml`,
 `deploy-add-config-init.yaml` (the ConfigMap→PVC bootstrap initContainer, appends
-onto the volumes the `pvc` component already added).
+onto the volumes the `pvc` component already added), and
+`deploy-update-resources.yaml` (`webapp/base`'s default `cpu: 10m` throttles a
+Node.js process badly — bumped to `500m`/`100m` request after confirming via
+the live pod's `cgroup cpu.stat` that it was throttled >99% of the time).
 
 ## Config
 
@@ -28,10 +29,20 @@ onto the volumes the `pvc` component already added).
 - Both apps write their SOPS-encrypted config directly into a ConfigMap
   (`configMap.yaml`); an initContainer copies it onto a PVC on first boot so
   the app can write its own state (device DB, retained MQTT data) without
-  mutating the ConfigMap.
-- `permit_join: true` in zigbee2mqtt's config leaves the network open to new
-  device joins indefinitely — flip to `false` in `configMap.yaml` once
-  pairing is done, and re-encrypt with `sops --encrypt --in-place`.
+  mutating the ConfigMap. This means editing `configMap.yaml` only affects
+  *new* PVCs — an already-seeded one keeps its own copy (zigbee2mqtt owns it
+  from there, e.g. writing back paired devices).
+- zigbee2mqtt runs 2.x (`configMap.yaml` uses the 2.x schema: `homeassistant`
+  is an object now, not a bare boolean; `frontend` needs `enabled: true`).
+  Pairing new devices: **`permit_join` is not a config file setting in 2.x**
+  — it was removed upstream in favor of the frontend UI or an MQTT command
+  (`zigbee2mqtt/bridge/request/permit_join`, payload `{"value": true}`),
+  since a static "always open" toggle in config defeats the point. Toggle it
+  there when you need to pair, not here.
+- Upgrading the image tag on an already-seeded PVC: zigbee2mqtt has its own
+  automatic config migration (runs in-place on boot, backs up the pre-migration
+  file) — no manual intervention needed even though the initContainer won't
+  re-copy `configMap.yaml`'s newer schema onto an existing PVC.
 
 ## Troubleshooting
 

--- a/kubernetes/apps/home-automation/zigbee2mqtt/configMap.yaml
+++ b/kubernetes/apps/home-automation/zigbee2mqtt/configMap.yaml
@@ -3,21 +3,19 @@ kind: ConfigMap
 metadata:
     name: settings
 data:
-    configuration.yaml: ENC[AES256_GCM,data:GkwGUj8sRf9nl4wCw1ReatwBDbEyeUvz4gimCNbCEGMaHo1FvXvIL2vZueYIwBbBnmMfCBZIPsb2u5oyHUREZVIszAbCYYIY+OIZ4oFhd0dsiw4TaDNjSwBPsRkTuMEJKo6QSVioLmKoglnVbzpqTNwCzcx4F89Sx4tN8+cwZ2NOCeOXBSangNAr/07tlkcB9qDQNWXgRF0PW32C7Noz2rDjl9A4fPgS0AN8aAkK9q1fYlCMOzwqVXmjMvQFpwstHQsT66LkrGv8e5CZRNol8ZmTFfGTwH8iF+ZQqWMKjPpCqQdH5+KgQFypCfm0N0NYJ/BIubyV+4TKE+LvyGfDoaxV2WpGhSknkMgYLJblOA9CG+Vw/9we83bZM4VSd7S8qclrEd6bWb/SA2k35EvT1hMF47lNybRGZaVlEufepkPrvZ1MBRywvHBTFun6s6vLILgOR2NL88sM5jIQ4l42AsDhyGynNc4e1U5RRbKg8QNWL/iGp375Ry9Qd3MdI9bTCVh40hU1ekh0lGqD1Ei8Pg3sb0lJAkmWdXh86YJCXJI20nrrbFXiseDmOUIy/jaBGrpgwszCKHdFRv1db1uk+LzE+V9UL0WTYoyE1jmauoo1fg/uQbkRqYWFAeKyvgS2NyKBUlKA0z+Gtw8qXpfTpwPj5lhJsW+1W4kiA3lHB/UMCAsmz7obCVoRtojeS3X8wx0zWD/R,iv:DwrHzJtn1dEJmqIRKQqzTEutILfQeF/hU11pExAEhKM=,tag:5BjHK1L7CTWxPHvSgy/4fw==,type:str]
-    devices.yaml: ""
-    groups.yaml: ""
+    configuration.yaml: ENC[AES256_GCM,data:/2RB6hh718hWpYnY+cKvuXNVQwxDDJUOWnAKUUBae8aEZU4gxMkaVunuE8310pSf9+b1b82Rk3cAAvh/PWfLEX/bY5SPlYxkcCH9O9a+Ddj3bxcdg28ne7s2dPWPEW2hOUq2avyRCJeCJuJSWsT/LJ+xODCX9yczC2w1qNjkwx2HGQiiKeDMPR7q22LDOouUVU+fvZ9hYOTfG6mXfc8F/E1OdhtCUY9WbETFmdMtsCr06vRLZBkolbVNg9aDysc+GqzLiH1IttL6CJb9G83TugStMLgbIIrjEFI720g/IEj55j+TilUP16xSTvsvLCTXvuqBuirOqjfRiw2nMYDwZpme5GLAaWLpOtwlqjwMZR1/L113jTqN1QPavFaWDxuqLXAQuG+mQK+ySD/fFXm8QYkR7ZeG9ewqe5vY3/1nlP+yinDd/lVFDSFBtDt1jSLbyChBzV3I2RuaYQky6cNCGbcLhV+Mz8HL74Z2ANv9Bsw+RUsOHCjg1Bj21rdvP5qio9zjvfY7uC3zjB7VdD9oc698hEmlEThk2hQI2GBsXFi6gNIQkCy8ZcW0sm4xBGjY5bJA/UU4BhFuD/o=,iv:hiOJrQj2d6TH9iGsZjoV/lNGfJUngM/vr/BztSRh3Cw=,tag:40mbFsxlmrXLe8sgchKiIA==,type:str]
 sops:
     age:
         - enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBnKzd6K2JON2J3Q1NrQm1n
-            RXo5QUY3VENLU1ZJUXlISjJyYnR6d0pkZGhVCnUvdEJsL3JIaEhIbG9CYkxKclkx
-            TDlGeFQyTFVrVVpHaWc2RFpULzdXZDgKLS0tIDRaRjRaejU4ODBianFDWTRLQkJy
-            bWdTeVFqL1Zqa0F6S0tXUm9JQUd2cjQKSjGTDf5lpKcY2WaOAHLXpKz5xCmd+/dM
-            Y9Of+L9ZTzjOea5ygbHrItaKOpBrcIft/RTBE9TwY6FwYS8waJCwxQ==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSB1UkE3Qi9CM0J2eGlodGRB
+            blY2ekh0TFYyVDZmRUlhK1BmcG5OUWFyUTE4CllKS0FuWXlrZHYza3VRalVWa3ov
+            TUN3d3BHNDFIUHBOSXFjc2dlWGFpTG8KLS0tICtidU9GU2NzTlJLSHBaRm9NMjk5
+            MXRXcHVqcXJQQmJLcytQN3JmQkVXODgKCC4qgzmUN2FueNdq2VBfubTEErto3uq3
+            I7Ntdd+du/1lic0eBYap9S9hPxef/6Nk0ht49OlSQIaQDXLkdbcO/w==
             -----END AGE ENCRYPTED FILE-----
           recipient: age13tszh09s5hr9hzjdy8enq7uncz9p2z09hsvky2dn25vudr4cx37s6k5n9z
     encrypted_regex: ^(data|stringData)$
-    lastmodified: "2026-08-07T17:34:50Z"
-    mac: ENC[AES256_GCM,data:Id12k2k0lKrmdlSb1dxv41JFRQfDXH6Ln8eeh80wlzFoCl3ax7nTbAFWGqE0+OMTiebfPMxUg/R7aU6PmfvdmXNg4UUTE0Stc2p2U6yR4Xa0Pf761TvKwtmlmFjTBw1j9v0TmOyNYnwl33gHZ3fw8f9bMU862EMm/TxJeu842ek=,iv:yPBVaF3EgcR0ne/E6WhbZGdU80UoD+wTpDMrmnKTylg=,tag:uVEiz3Z55ZYg5HDGC7toLg==,type:str]
+    lastmodified: "2026-08-07T19:51:37Z"
+    mac: ENC[AES256_GCM,data:6qek+CG+zROVq0L1W5Ys+jaR40FTTji84J/u7ehwSWIRTCU9w0fb2g4D+FiVs5IXbWUJgZp22ywmDyXMxcNtJpmGHC29Mi8Cw7uJPZIuYJhrGUJ1APSMXadfUeclYdLmRIImw8crg42orrUn6mjAYZJ7iHqaS0+N019yGzkmV8g=,iv:RbmTXkwUf9Cnpylc1mfzz2fy9xvl2Jv3TR/OFT/yyHc=,tag:peA9dpU0KR2VRo5nLlHyaw==,type:str]
     version: 3.13.0

--- a/kubernetes/apps/home-automation/zigbee2mqtt/kustomization.yaml
+++ b/kubernetes/apps/home-automation/zigbee2mqtt/kustomization.yaml
@@ -20,7 +20,7 @@ components:
 images:
   - name: my-app
     newName: koenkk/zigbee2mqtt
-    newTag: "1.38.0"
+    newTag: "2.13.0"
 
 patches:
   - target:


### PR DESCRIPTION
Latest stable per \`gh api repos/Koenkk/zigbee2mqtt/releases/latest\` — \`2.13.0\`, released 2026-08-01. Previous pin (\`1.38.0\`) was from mid-2024.

## Why this needed more than a tag bump

1.x → 2.x is a breaking release for \`configuration.yaml\`. Rather than guess, I pulled zigbee2mqtt's own JSON schema (\`lib/util/settings.schema.json\`) and migration source (\`lib/util/settingsMigration.ts\`) at tag \`2.13.0\` and validated our new config against the real schema with \`jsonschema\` before committing anything.

**Schema changes that hit our config:**
- \`homeassistant: true\` → \`homeassistant: {enabled: true, discovery_topic, status_topic}\` — was a bare boolean, now an object. \`advanced.homeassistant_discovery_topic\`/\`status_topic\` moved inside it.
- \`frontend\` now requires \`enabled: true\` explicitly — \`port\` alone no longer implies the frontend is on.
- \`experimental\` section removed entirely (drops our \`experimental.new_api: true\`, which is meaningless in 2.x anyway).
- \`devices\`/\`groups\` can no longer reference an external filename (\`devices: devices.yaml\`) — schema now requires them to be inline objects. Ours were both empty (no devices paired yet), so this was a clean drop, no data to migrate.
- **\`permit_join\` is no longer a config file setting at all.** Confirmed via \`settingsMigration.ts\`: *"The permit_join setting has been removed, use the frontend or MQTT to permit joining."* Updated the README to point at the frontend UI / \`zigbee2mqtt/bridge/request/permit_join\` MQTT command instead of carrying a dead key.

## The PVC wrinkle

Our initContainer only seeds \`configuration.yaml\` onto a PVC once (\`if [ ! -f configuration.yaml ]\`) — it won't re-copy this updated ConfigMap onto the already-running pod's existing PVC. That's fine: zigbee2mqtt ships its own automatic in-place config migration (confirmed in \`settingsMigration.ts\`) that runs on boot and backs up the pre-migration file. So:
- **Live pod** (already-seeded PVC): boots 2.13.0, finds the old 1.x-format file, self-migrates in place. No action needed from this PR.
- **Any future fresh PVC**: starts pre-migrated, using this PR's native 2.x config directly.

Documented this split in the README so it isn't a surprise later.

## Verification

- Every key in the new config checked against \`lib/util/settings.schema.json\` — schema-valid via \`jsonschema.Draft7Validator\`, no errors.
- \`task gen:validate\` / \`task test:build\` — clean.
- Not yet re-verified against the live cluster post-merge — worth watching \`kubectl logs -n home-automation deploy/zigbee2mqtt-deploy\` after this reconciles to confirm the auto-migration runs cleanly and the frontend comes back up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)