### PR TITLE
fix: zigbee2mqtt 2.x crashes on stale empty devices.yaml/groups.yaml

### DIFF
--- a/kubernetes/apps/home-automation/zigbee2mqtt/patches/deploy-add-config-init.yaml
+++ b/kubernetes/apps/home-automation/zigbee2mqtt/patches/deploy-add-config-init.yaml
@@ -12,7 +12,16 @@
       command: ["sh", "-c"]
       args:
         [
-          "if [ ! -f '/dest/configuration.yaml' ] ; then cp -Lr /src/* /dest/ && chmod -R +w /dest/ ; fi",
+          # devices.yaml/groups.yaml are stale — leftover 0-byte files from
+          # the pre-2.x external-file-reference config, no longer written
+          # by the seed ConfigMap. An empty file fails zigbee2mqtt 2.x's
+          # YAML parse (js-yaml throws on truly-empty input) before it
+          # even gets to run its own config migration, so the app never
+          # boots. Removed unconditionally (idempotent, safe once already
+          # gone) rather than gated behind the configuration.yaml check,
+          # since it must run on every boot until the stale files are gone
+          # from the PVC, not just the first one.
+          "if [ ! -f '/dest/configuration.yaml' ] ; then cp -Lr /src/* /dest/ && chmod -R +w /dest/ ; fi; rm -f /dest/devices.yaml /dest/groups.yaml",
         ]
       volumeMounts:
         - name: config-src


### PR DESCRIPTION
Follow-up to #91 — the image/config update landed, but the live pod won't actually boot:

\`\`\`
!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
            READ THIS CAREFULLY

Refusing to start because configuration is not valid, found the following errors:
- Your configuration file: '/data/devices.yaml' is invalid (use https://jsonformatter.org/yaml-validator to find and fix the issue)
!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
\`\`\`

## Root cause

Confirmed by running the actual bundled \`js-yaml\` inside the live container (\`kubectl exec ... node -e \"...\"\`, read-only, no cluster mutation):

\`\`\`
$ node -e "require('js-yaml').load('')"
THREW: YAMLException expected a document, but the input is empty
\`\`\`

\`/data/devices.yaml\` and \`/data/groups.yaml\` are genuinely 0 bytes — leftovers from the very first (na-era) boot, back when \`configuration.yaml\` referenced them as \`devices: devices.yaml\` / \`groups: groups.yaml\` (the pre-2.x external-file-reference pattern #91 dropped from the ConfigMap).

zigbee2mqtt's \`onboard()\` calls \`settings.getPersistedSettings()\` — which resolves those external file references — **before** \`migrateIfNecessary()\` ever runs. So it crashes trying to parse the stale empty file before it gets a chance to migrate \`configuration.yaml\` to the 2.x schema and drop the references for good.

#91 already removed \`devices.yaml\`/\`groups.yaml\` from the ConfigMap, so this only affects the *already-seeded* PVC from before that PR — a fresh PVC would never hit it.

## Fix

The initContainer's copy step is (correctly) gated behind "only on first boot" (\`if [ ! -f configuration.yaml ]\`), but cleaning up these two stale files needs to happen on *every* boot until they're actually gone — so it's now unconditional and idempotent (\`rm -f /dest/devices.yaml /dest/groups.yaml\`), not folded into that same first-boot check.

## Verification

- \`task gen:validate\` / \`task test:build\` — clean.
- Root-caused via read-only \`kubectl exec\` against the live pod (log inspection + reproducing the exact exception with \`node -e\`) — no direct cluster changes.
- Not yet re-verified post-merge — next boot (triggered automatically once this reconciles, \`Recreate\` strategy) should get past onboarding and into zigbee2mqtt's own config migration. Worth watching the logs once this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)