### PR TITLE
fix: re-seed zigbee2mqtt config, hits a known upstream migration bug

### DIFF
--- a/kubernetes/apps/home-automation/zigbee2mqtt/patches/deploy-add-config-init.yaml
+++ b/kubernetes/apps/home-automation/zigbee2mqtt/patches/deploy-add-config-init.yaml
@@ -21,7 +21,18 @@
           # gone) rather than gated behind the configuration.yaml check,
           # since it must run on every boot until the stale files are gone
           # from the PVC, not just the first one.
-          "if [ ! -f '/dest/configuration.yaml' ] ; then cp -Lr /src/* /dest/ && chmod -R +w /dest/ ; fi; rm -f /dest/devices.yaml /dest/groups.yaml",
+          #
+          # Re-seed configuration.yaml if it's still the pre-2.x format
+          # (literal "homeassistant: true" line — our current ConfigMap
+          # never writes that, only "homeassistant:" as a block). zigbee2mqtt
+          # 2.x has a known upstream migration bug that crashes on exactly
+          # this combination (homeassistant: true + advanced.homeassistant_
+          # discovery_topic set) — see Koenkk/zigbee2mqtt#25518, closed
+          # "not planned", fix is to already be on the new schema. Safe to
+          # force here since no devices are paired yet (nothing to lose);
+          # self-limiting once the seeded config is current, since the
+          # marker won't match anymore.
+          "if [ ! -f '/dest/configuration.yaml' ] || grep -q '^homeassistant: true$' /dest/configuration.yaml 2>/dev/null; then cp -Lr /src/* /dest/ && chmod -R +w /dest/ ; fi; rm -f /dest/devices.yaml /dest/groups.yaml",
         ]
       volumeMounts:
         - name: config-src


### PR DESCRIPTION
Follow-up to #92 — got past the \`devices.yaml\` crash, but the pod now crashes differently once it reaches its own migration code:

\`\`\`
TypeError: Cannot create property 'discovery_topic' on boolean 'true'
    at setValue (/app/lib/util/settingsMigration.ts:54:33)
    at transferValue (/app/lib/util/settingsMigration.ts:179:13)
    at migrateIfNecessary (/app/lib/util/settingsMigration.ts:594:60)
\`\`\`

## Root cause

This is a **known upstream bug**, not something specific to our config — [Koenkk/zigbee2mqtt#25518](https://github.com/Koenkk/zigbee2mqtt/issues/25518) (and #25534, #25470, #25443), all closed "not planned".

\`migrateToTwo()\` transfers \`advanced.homeassistant_discovery_topic\` → \`homeassistant.discovery_topic\` *before* the \`homeassistant: true\` → \`{enabled: true}\` boolean-to-object conversion runs. If both are present at once (our config has exactly this: \`homeassistant: true\` set explicitly alongside customized discovery/status topics), it tries to set a property on a boolean and throws. Maintainers' answer in that thread: the config needs to already be in the new object-shaped format going in — they didn't fix the migration path itself.

Our #91 already writes \`configMap.yaml\` in exactly that already-migrated format. The bug only hits the **already-seeded PVC's stale pre-migration file** — our initContainer's "copy on first boot only" guard was (correctly) protecting that file from being touched, which is exactly what's now in the way.

## Fix

Extended the initContainer's copy condition to also re-seed when the persisted \`configuration.yaml\` is still detectably pre-2.x (literal \`homeassistant: true\` line — our current ConfigMap never produces that, only \`homeassistant:\` as a block). Safe to force here since no devices are paired yet, nothing to lose; self-limiting afterward since the marker stops matching once the seeded config is current.

## Verification

- Tested the shell condition standalone against old-format / new-format / missing-file cases before wiring it into the manifest — all three behave correctly.
- \`task gen:validate\` / \`task test:build\` — clean.
- Root-caused via the live pod's crash logs + upstream issue search, read-only only — no direct cluster changes.
- Not yet re-verified post-merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved configuration migration by detecting legacy configuration formats and reseeding them automatically.
  - Continued cleanup of outdated device and group configuration files during initialization.

- **Documentation**
  - Added comments explaining the legacy-format migration behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->