### PR TITLE
fix: zigbee-herdsman 10.x needs serial.adapter set explicitly

### DIFF
--- a/kubernetes/apps/home-automation/zigbee2mqtt/configMap.yaml
+++ b/kubernetes/apps/home-automation/zigbee2mqtt/configMap.yaml
@@ -3,19 +3,19 @@ kind: ConfigMap
 metadata:
     name: settings
 data:
-    configuration.yaml: ENC[AES256_GCM,data:/2RB6hh718hWpYnY+cKvuXNVQwxDDJUOWnAKUUBae8aEZU4gxMkaVunuE8310pSf9+b1b82Rk3cAAvh/PWfLEX/bY5SPlYxkcCH9O9a+Ddj3bxcdg28ne7s2dPWPEW2hOUq2avyRCJeCJuJSWsT/LJ+xODCX9yczC2w1qNjkwx2HGQiiKeDMPR7q22LDOouUVU+fvZ9hYOTfG6mXfc8F/E1OdhtCUY9WbETFmdMtsCr06vRLZBkolbVNg9aDysc+GqzLiH1IttL6CJb9G83TugStMLgbIIrjEFI720g/IEj55j+TilUP16xSTvsvLCTXvuqBuirOqjfRiw2nMYDwZpme5GLAaWLpOtwlqjwMZR1/L113jTqN1QPavFaWDxuqLXAQuG+mQK+ySD/fFXm8QYkR7ZeG9ewqe5vY3/1nlP+yinDd/lVFDSFBtDt1jSLbyChBzV3I2RuaYQky6cNCGbcLhV+Mz8HL74Z2ANv9Bsw+RUsOHCjg1Bj21rdvP5qio9zjvfY7uC3zjB7VdD9oc698hEmlEThk2hQI2GBsXFi6gNIQkCy8ZcW0sm4xBGjY5bJA/UU4BhFuD/o=,iv:hiOJrQj2d6TH9iGsZjoV/lNGfJUngM/vr/BztSRh3Cw=,tag:40mbFsxlmrXLe8sgchKiIA==,type:str]
+    configuration.yaml: ENC[AES256_GCM,data:qJdf24aKCr4/sQLIUP6hnarQEfQ7oaB/86YQvOdwdBrGGiZxOHnS4muqAzG0PV8R7r+btnJypAvZFDs3ZX2IQHOLuEO/Pv2wppiIRwTuvjMfy1nm7n/fvCPH1aRPPGfk9X51c3H2As7xNLZhekp49IC2WJl0qb9XYr7DR2gzUd/A7zZSEgRm5mpvqZCUwQS/b+rv+O59DT4izdS7xldFjhxHjm6gAcK3bDYw0ej/LI6krBMCpNkSD4OlGYXmznCKyMapo7btlI9OQWHF3vOkQfWJXMZYzggjT6SeHIwUPiLCtz23ZA0w/D9/CWur2bT8QDbJwZmQfipmX4qFjpp27hYiSwIYbZZ5yO9IPIzo+88pxQ+Ku4Am8zhv4bevM4rKPaJeHheaaYDB5+zXxyrzUYboAsbSsiBkWXki84C7Vyu7QJHAXZvJGnv3YLznSedVYGMbfoEMMDqRPtfJniocDNuUIzYjdD6DbN5BkJoh/FThYvfyyAOZ6DElyV6UlM5vaYEcfy+qGYnG7ft12lTJpAnXAq8iq2WAZdCRD+ZEk16yZYkT6sDqsnjFlBmP6nkjLiZ0mnSfSZNxvXwAZzvl9Zs3auG0PFq292EA5dI=,iv:mRKFiINeq8muE386pL6C8sO4YBbVJ/NKqOqS7LzASAk=,tag:sOcyhNXR2CI6UClwmwtGww==,type:str]
 sops:
     age:
         - enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSB1UkE3Qi9CM0J2eGlodGRB
-            blY2ekh0TFYyVDZmRUlhK1BmcG5OUWFyUTE4CllKS0FuWXlrZHYza3VRalVWa3ov
-            TUN3d3BHNDFIUHBOSXFjc2dlWGFpTG8KLS0tICtidU9GU2NzTlJLSHBaRm9NMjk5
-            MXRXcHVqcXJQQmJLcytQN3JmQkVXODgKCC4qgzmUN2FueNdq2VBfubTEErto3uq3
-            I7Ntdd+du/1lic0eBYap9S9hPxef/6Nk0ht49OlSQIaQDXLkdbcO/w==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSAwSURLREtMbzZqNW4xNEZ6
+            Q0NWNFFGV3c3SWlXTStpQm9nTGQyWVhtN0NvCkl3MVN2cldSYkkrbktyR0R1dlJ6
+            aDg0d1RxNjVWU244T2xVeDdVYjJkelEKLS0tIGZOZW5JMVRtb1VjRzZCNWQyRnA5
+            eFNGbnpBUFlYRWo1L296Nk5wL25SOUEK8s1MYGMFuTxMtn8ioQ8DIGBfUhVhGOa1
+            7DiRRMW+b0F3KgiGX+HMlB6xRqmkF64ofH//N9UqYAgJnenlBLy8gg==
             -----END AGE ENCRYPTED FILE-----
           recipient: age13tszh09s5hr9hzjdy8enq7uncz9p2z09hsvky2dn25vudr4cx37s6k5n9z
     encrypted_regex: ^(data|stringData)$
-    lastmodified: "2026-08-07T19:51:37Z"
-    mac: ENC[AES256_GCM,data:6qek+CG+zROVq0L1W5Ys+jaR40FTTji84J/u7ehwSWIRTCU9w0fb2g4D+FiVs5IXbWUJgZp22ywmDyXMxcNtJpmGHC29Mi8Cw7uJPZIuYJhrGUJ1APSMXadfUeclYdLmRIImw8crg42orrUn6mjAYZJ7iHqaS0+N019yGzkmV8g=,iv:RbmTXkwUf9Cnpylc1mfzz2fy9xvl2Jv3TR/OFT/yyHc=,tag:peA9dpU0KR2VRo5nLlHyaw==,type:str]
+    lastmodified: "2026-08-07T20:51:20Z"
+    mac: ENC[AES256_GCM,data:k5pCUpFb+C3wIZJupahp+5OTcakETTgNZSQLn4/X3Mx/FA1s8SebzWS6QtjdXf/qh26vS1F4CHsZCNLtALC8MBckgZR164snfMluuIuBB+rXUW988P1DZZUKaieqX0zgCvPocdyRpH1eXKSMnprlkSFn95Ri0XmHL/KqPrDFBxE=,iv:TlpFSh9wk09flA4f0DlJ+YCjbh8L77vjniZUgeeEENs=,tag:eF3gjv7JSKq/pCdmJfrAEQ==,type:str]
     version: 3.13.0

--- a/kubernetes/apps/home-automation/zigbee2mqtt/patches/deploy-add-config-init.yaml
+++ b/kubernetes/apps/home-automation/zigbee2mqtt/patches/deploy-add-config-init.yaml
@@ -12,27 +12,24 @@
       command: ["sh", "-c"]
       args:
         [
-          # devices.yaml/groups.yaml are stale — leftover 0-byte files from
-          # the pre-2.x external-file-reference config, no longer written
-          # by the seed ConfigMap. An empty file fails zigbee2mqtt 2.x's
-          # YAML parse (js-yaml throws on truly-empty input) before it
-          # even gets to run its own config migration, so the app never
-          # boots. Removed unconditionally (idempotent, safe once already
-          # gone) rather than gated behind the configuration.yaml check,
-          # since it must run on every boot until the stale files are gone
-          # from the PVC, not just the first one.
+          # Re-seeds configuration.yaml from the ConfigMap whenever
+          # SEED_VERSION doesn't match what's recorded in the PVC's
+          # .z2m-seed-version — not just on first boot. Bump SEED_VERSION
+          # any time configMap.yaml's configuration.yaml content changes
+          # and needs to land on an already-seeded PVC (zigbee2mqtt owns
+          # configuration.yaml after that — this only overwrites when the
+          # version marker is stale, so it won't clobber runtime state
+          # like a generated network_key once the network's actually up).
+          # Replaces two prior one-off content-sniffing hacks (stale
+          # "homeassistant: true", missing devices.yaml/groups.yaml) that
+          # each needed this same re-seed but detected it ad hoc.
           #
-          # Re-seed configuration.yaml if it's still the pre-2.x format
-          # (literal "homeassistant: true" line — our current ConfigMap
-          # never writes that, only "homeassistant:" as a block). zigbee2mqtt
-          # 2.x has a known upstream migration bug that crashes on exactly
-          # this combination (homeassistant: true + advanced.homeassistant_
-          # discovery_topic set) — see Koenkk/zigbee2mqtt#25518, closed
-          # "not planned", fix is to already be on the new schema. Safe to
-          # force here since no devices are paired yet (nothing to lose);
-          # self-limiting once the seeded config is current, since the
-          # marker won't match anymore.
-          "if [ ! -f '/dest/configuration.yaml' ] || grep -q '^homeassistant: true$' /dest/configuration.yaml 2>/dev/null; then cp -Lr /src/* /dest/ && chmod -R +w /dest/ ; fi; rm -f /dest/devices.yaml /dest/groups.yaml",
+          # SEED_VERSION history:
+          #   1 - na-era config, 1.x schema
+          #   2 - 2.x schema migration (homeassistant object, frontend.enabled, etc.)
+          #   3 - serial.adapter: zstack (zigbee-herdsman 10.x can't
+          #       auto-discover the adapter type over tcp:// anymore)
+          "SEED_VERSION=3; if [ ! -f /dest/configuration.yaml ] || [ \"$(cat /dest/.z2m-seed-version 2>/dev/null)\" != \"$SEED_VERSION\" ]; then cp -Lr /src/* /dest/ && chmod -R +w /dest/ && echo \"$SEED_VERSION\" > /dest/.z2m-seed-version; fi; rm -f /dest/devices.yaml /dest/groups.yaml",
         ]
       volumeMounts:
         - name: config-src


### PR DESCRIPTION
Follow-up to #93 — migration crash fixed, zigbee-herdsman starts, but fails immediately:

\`\`\`
Error: Cannot discover TCP adapters at this time. Specify valid 'adapter' and 'port' in your configuration.
    at findTcpAdapter (.../zigbee-herdsman/src/adapter/adapterDiscovery.ts:606:15)
\`\`\`

## Root cause

zigbee-herdsman jumped \`0.49.2\` → \`10.8.0\` in this upgrade. In 10.x, TCP adapter auto-detection was removed entirely — \`serial.adapter\` is now a hard requirement for \`tcp://\` paths, not optional like it used to be.

We already know the right value: our own coordinator's pre-upgrade logs (back on 1.38.0) show \`zh:zstack:znp: ... Skip bootloader for CC2652/CC1352\` — this is a TI Z-Stack radio. \`adapter: zstack\` is confirmed against zigbee2mqtt's own schema enum, not a guess.

## Also: replaced the re-seed hacks with a real mechanism

This is the third config content change in a row (#91's schema migration, #93's format fix, now this) that needed the already-seeded PVC re-synced from the ConfigMap. #92/#93 each added a one-off content-sniffing condition (missing file, specific stale string) to detect "needs re-seeding" — that doesn't scale.

Replaced both with a \`SEED_VERSION\` marker (\`.z2m-seed-version\` written into the PVC alongside \`configuration.yaml\`). Re-seeds whenever the recorded version doesn't match, leaves it alone otherwise — so it won't clobber real runtime state (e.g. a generated \`network_key\`) once the network's actually up and devices are paired. Bump \`SEED_VERSION\` next time \`configMap.yaml\` changes and needs to reapply.

## Verification

- Tested the re-seed condition standalone against all four PVC states (fresh / current / stale-version / marker-file-missing) before wiring it in — all correct, including the one that matters right now: the live PVC has no \`.z2m-seed-version\` yet, so it re-seeds.
- \`task gen:validate\` / \`task test:build\` — clean.
- Not yet re-verified post-merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)