### PR TITLE
feat: add Home Assistant to orion

### DIFF
--- a/kubernetes/apps/home-automation/README.md
+++ b/kubernetes/apps/home-automation/README.md
@@ -1,56 +1,114 @@
 # home-automation
 
-MQTT stack: Mosquitto (broker) + Zigbee2MQTT (Zigbee bridge). Wired into
-orion via `kubernetes/clusters/orion/home-automation.yaml`, namespace
-`home-automation`.
+MQTT stack + Home Assistant, namespace `home-automation` for all three apps
+(so they can reach `mosquitto` by short name). Wired into orion via
+`kubernetes/clusters/orion/home-automation.yaml`, which holds **two** Flux
+Kustomization CRs (`---`-separated in one file, same pattern
+`cert-manager.yaml`/`gateway.yaml` already use for co-located CRs):
+
+- `home-automation` → `./kubernetes/apps/home-automation` (mosquitto + zigbee2mqtt)
+- `homeassistant` → `./kubernetes/apps/home-automation/homeassistant` directly (bypasses the aggregator)
 
 ## Components
 
 | Subdirectory | Purpose |
 |-------------|---------|
-| `mosquitto/` | MQTT message broker. Standalone manifests, no HTTP surface — `webapp/base` doesn't buy anything here, same reasoning as `external-endpoints`. |
+| `mosquitto/` | MQTT broker. Standalone manifests, no HTTP surface — `webapp/base` doesn't buy anything here. |
 | `zigbee2mqtt/` | Zigbee coordinator bridge → MQTT. Built on `../../webapp/base` + `httproute`/`pvc` components, frontend at `z2m.${domain}`. |
+| `homeassistant/` | Home Assistant. Also built on `../../webapp/base` + `httproute`/`pvc` components, frontend at `ha.${domain}`. |
 
-`zigbee2mqtt/patches/`: `httproute-add-homepage-annotations.yaml`,
-`deploy-add-config-init.yaml` (the ConfigMap→PVC bootstrap initContainer, appends
-onto the volumes the `pvc` component already added), and
-`deploy-update-resources.yaml` (`webapp/base`'s default `cpu: 10m` throttles a
-Node.js process badly — bumped to `500m`/`100m` request after confirming via
-the live pod's `cgroup cpu.stat` that it was throttled >99% of the time).
+### Why homeassistant is a separate Flux Kustomization CR
+
+One Flux `Kustomization` = one flat `postBuild.substitute` namespace — every
+`${VAR}` in its entire rendered output gets replaced from the same map, with
+no per-resource scoping. The `httproute`/`pvc` components both rely on
+generic vars (`${appName}`, `${subdomain}`, `${storageClass}`/`${storageSize}`)
+that need *different* values per app. `zigbee2mqtt` already claims those
+inside the `home-automation` Kustomization; folding `homeassistant` into the
+same one would mean both apps' `HTTPRoute`s resolving `${subdomain}` to
+whichever value happened to be set last — silently wrong, not a build error.
+
+Giving `homeassistant` its own Kustomization CR (pointing directly at
+`homeassistant/`, skipping the `mosquitto`+`zigbee2mqtt` aggregator) gives it
+its own substitute namespace, so both apps get full, uncompromised use of the
+shared components. `${domain}`/`${gatewayName}` don't have this problem —
+those come from `cluster-settings` (`substituteFrom`, not the literal
+`substitute` map) and are genuinely the same value for every app in the
+cluster.
+
+If a fourth home-automation app needs `httproute`/`pvc`, give it a third Flux
+Kustomization CR the same way, or hardcode its resources like `mosquitto/`
+does if it doesn't need real parameterization.
+
+### The seed-config pattern (all three apps)
+
+Each app's `configMap.yaml` (SOPS-encrypted) holds its initial config; an
+initContainer copies it onto a PVC. None of these apps should have their
+whole config directory overwritten on every boot — they write real state
+into it (zigbee2mqtt: paired devices, network key; Home Assistant: the
+recorder DB, `.storage/`; mosquitto's is closer to stateless, but the
+pattern's kept consistent).
+
+- **zigbee2mqtt / homeassistant** use a `SEED_VERSION` marker
+  (`.z2m-seed-version` / `.seed-version` on the PVC): re-copies only when the
+  version baked into the initContainer's `args` doesn't match what's
+  recorded on the PVC, otherwise leaves it alone. Bump the version any time
+  `configMap.yaml`'s config content changes and needs to land on an
+  already-seeded PVC.
+- **mosquitto**'s initContainer re-copies unconditionally on every boot
+  (its config is simple enough that this is safe), so ConfigMap changes
+  need a pod restart to take effect — nothing kubectl-mutates that
+  automatically, so `deployment.yaml`'s pod template carries a
+  `home-lab-ops/config-generation` annotation to bump by hand when that's
+  needed (forces a real rollout since the pod template itself changes).
 
 ## Config
 
-- Zigbee2MQTT publishes to Mosquitto over `mqtt://mosquitto:1883`; both apps
-  share the `home-automation` namespace so the short Service name resolves.
+- Zigbee2MQTT and Home Assistant both talk to Mosquitto over
+  `mosquitto:1883` / `mosquitto.home-automation.svc.cluster.local:1883`
+  (short name works since they're all in the same namespace).
 - Zigbee2MQTT's `serial.port` points at the SLZB-06 coordinator's ser2net
   TCP passthrough (`tcp://10.50.0.150:6638`) — same device wired in as
   `apps/external-endpoints/slzb-06` for its own admin UI at
-  `zigbee.${domain}`. Don't confuse the two hostnames.
-- Both apps write their SOPS-encrypted config directly into a ConfigMap
-  (`configMap.yaml`); an initContainer copies it onto a PVC on first boot so
-  the app can write its own state (device DB, retained MQTT data) without
-  mutating the ConfigMap. This means editing `configMap.yaml` only affects
-  *new* PVCs — an already-seeded one keeps its own copy (zigbee2mqtt owns it
-  from there, e.g. writing back paired devices).
-- zigbee2mqtt runs 2.x (`configMap.yaml` uses the 2.x schema: `homeassistant`
-  is an object now, not a bare boolean; `frontend` needs `enabled: true`).
-  Pairing new devices: **`permit_join` is not a config file setting in 2.x**
-  — it was removed upstream in favor of the frontend UI or an MQTT command
-  (`zigbee2mqtt/bridge/request/permit_join`, payload `{"value": true}`),
-  since a static "always open" toggle in config defeats the point. Toggle it
-  there when you need to pair, not here.
-- Upgrading the image tag on an already-seeded PVC: zigbee2mqtt has its own
-  automatic config migration (runs in-place on boot, backs up the pre-migration
-  file) — no manual intervention needed even though the initContainer won't
-  re-copy `configMap.yaml`'s newer schema onto an existing PVC.
+  `zigbee.${domain}`. Don't confuse the two hostnames. `serial.adapter:
+  zstack` is required explicitly (zigbee-herdsman 10.x can't auto-detect
+  over TCP) — confirmed against this coordinator's own logs (TI CC2652).
+- zigbee2mqtt runs 2.x. `permit_join` is **not** a config file setting in
+  2.x — toggle it via the frontend or
+  `zigbee2mqtt/bridge/request/permit_join` (`{"value": true}`) when
+  pairing new devices, not in git.
+- Home Assistant's seed config sets `http.trusted_proxies:
+  10.241.0.0/16` (orion's pod CIDR, from `talconfig.yaml` — required or HA
+  rejects requests coming through the Gateway) and
+  `homeassistant.external_url`. Resource limits are set well above
+  `webapp/base`'s defaults from the start (`1` cpu / `1Gi` mem limit) —
+  zigbee2mqtt's `webapp/base` default of `cpu: 10m` throttled it badly
+  (#90); no reason to rediscover that here.
+- **First boot of Home Assistant needs a human**: visiting `ha.${domain}`
+  walks through HA's own onboarding (create the admin account, name the
+  instance) — nothing about that is config-file-representable, so it isn't
+  automated here. After that, add the MQTT integration via *Settings →
+  Devices & services → Add integration → MQTT*
+  (`homeassistant/secret.yaml` has the broker credentials —
+  `mosquitto.home-automation.svc.cluster.local:1883`). zigbee2mqtt is
+  already publishing `homeassistant/...` discovery topics, so paired
+  Zigbee devices should show up automatically once MQTT is connected.
+- `mosquitto/configMap.yaml`'s `hass_mqtt_user` password was regenerated
+  from scratch when `homeassistant/` was added — the original (na-era)
+  plaintext was never recoverable, mosquitto only ever stored the hash.
+  The new plaintext lives in `homeassistant/secret.yaml` (SOPS).
 
 ## Troubleshooting
 
-- **MQTT broker unreachable:** check the `mosquitto` Service and that
-  `configMap.yaml` credentials (`z2m_mqtt_user` / `hass_mqtt_user`) match
-  what clients use.
+- **MQTT broker unreachable:** check the `mosquitto` Service and that the
+  credentials in use (`z2m_mqtt_user` / `hass_mqtt_user`) match
+  `mosquitto/configMap.yaml`'s `password_file`.
 - **Zigbee2MQTT can't reach the coordinator:** confirm the SLZB-06 is up at
   `10.50.0.150` and its ser2net port hasn't moved from `6638`.
-- **Config not applying:** the initContainer only copies config on first
-  boot (`if [ ! -f configuration.yaml ]`) — delete the PVC's contents or
-  exec in to force a re-copy after editing `configMap.yaml`.
+- **Home Assistant rejects requests / login weirdness behind the Gateway:**
+  check `http.trusted_proxies` in the seeded `configuration.yaml` still
+  covers the pod CIDR (`kubectl get ciliumnode` or `talconfig.yaml` if it's
+  ever changed).
+- **Config change not taking effect on an already-running pod:** see the
+  seed-config pattern above — bump `SEED_VERSION` (zigbee2mqtt/homeassistant)
+  or `home-lab-ops/config-generation` (mosquitto).

--- a/kubernetes/apps/home-automation/homeassistant/configMap.yaml
+++ b/kubernetes/apps/home-automation/homeassistant/configMap.yaml
@@ -1,0 +1,21 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+    name: settings
+data:
+    configuration.yaml: ENC[AES256_GCM,data:5xuLQWSKgOhGbAkZgMt29Mch0LXuraxfWLMlI8FDLRVFeouEZ2MJTfHcPRtYV/GORboiDrc0WDH2FNq0s8vEraiJvzIVVpvK1ixOo/b5+VDrlYuImSt+GpA3ZH2uy9pFVTJqshRdRv7WnLI2tnBP6FxPIe/46qxaVuLiI0sJIqva6wJ/sVTfEESCNk4yH5SLZheTxekkzoWO,iv:bkmZIlYjCwHBjEH9kTHeWVj8qnyt1js8opYALYDjtpg=,tag:8H6Foq9QAaEFxuKPNNEcBA==,type:str]
+sops:
+    age:
+        - enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSB4cUx4YlVDWktCdW8zT3lm
+            anF0QzQrNnhJbXRDamx0VUNUdHNGNTlIZ0MwCmFmTk9KWWMxRy9Zc05TZW5FVDlW
+            R0t2VlFlMkUxUGwzYkhVbnlPNzhGZzgKLS0tIEljaWtubkE5Y0podFZlMXZtd2Yr
+            QWF4aWtPVVRDN3BrM1drVUJoWkwzQ3cKajmvNpuVQwLv6RsfPkh5Vr8SkqfLnpWN
+            qqIFVkrb8gR8HpiO2CKF9+0/KIZEOqSgbPQBiVTBO25URQ6sxpbxEw==
+            -----END AGE ENCRYPTED FILE-----
+          recipient: age13tszh09s5hr9hzjdy8enq7uncz9p2z09hsvky2dn25vudr4cx37s6k5n9z
+    encrypted_regex: ^(data|stringData)$
+    lastmodified: "2026-08-08T01:04:11Z"
+    mac: ENC[AES256_GCM,data:LThPruADmd84jZ1KYrAk5ygoxboe4kC70K0hjQNPB7XNdqGZZO690TLR4gjgTg/ehTa6ivh0uKhk4Gyp0RM3/snGLJP343Ri7BKYBlcu6lQYeEqaTGAZSwfQ98Z9DaVUFHIB1DYo9c1LJMCAc694E18nTbgqbIFR+0YQtpFFwo4=,iv:fmT91z2cyLO0kL1RJRf4082XxcXUlRoi2WN/tojRVEs=,tag:f2koUipy6mVvPbR4vKq6NA==,type:str]
+    version: 3.13.0

--- a/kubernetes/apps/home-automation/homeassistant/kustomization.yaml
+++ b/kubernetes/apps/home-automation/homeassistant/kustomization.yaml
@@ -1,0 +1,56 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: home-automation
+
+resources:
+  - ../../webapp/base
+  - configMap.yaml
+  - secret.yaml
+
+namePrefix: homeassistant-
+
+labels:
+  - includeSelectors: true
+    pairs:
+      app: homeassistant
+      app.kubernetes.io/name: homeassistant
+
+components:
+  - ../../webapp/components/httproute
+  - ../../webapp/components/pvc
+
+images:
+  - name: my-app
+    newName: ghcr.io/home-assistant/home-assistant
+    newTag: "2026.8.1"
+
+patches:
+  - target:
+      kind: Deployment
+      name: deploy
+    path: patches/deploy-container-port.yaml
+  - target:
+      kind: Deployment
+      name: deploy
+    path: patches/deploy-add-env.yaml
+  - target:
+      kind: Deployment
+      name: deploy
+    path: patches/deploy-config-mountpath.yaml
+  - target:
+      kind: Deployment
+      name: deploy
+    path: patches/deploy-add-config-init.yaml
+  - target:
+      kind: Deployment
+      name: deploy
+    path: patches/deploy-update-resources.yaml
+  - target:
+      kind: Service
+      name: svc
+    path: patches/svc-target-port.yaml
+  - target:
+      kind: HTTPRoute
+      name: route
+    path: patches/httproute-add-homepage-annotations.yaml

--- a/kubernetes/apps/home-automation/homeassistant/patches/deploy-add-config-init.yaml
+++ b/kubernetes/apps/home-automation/homeassistant/patches/deploy-add-config-init.yaml
@@ -1,0 +1,29 @@
+# pvc component (applied first, before this app's own patches) already
+# adds the "data" volume + a volumeMount at /data on container 0 — this
+# only appends the config-src volume onto that (via /-, not a full
+# replace) and adds the initContainer. See
+# patches/deploy-config-mountpath.yaml for /data -> /config.
+- op: add
+  path: /spec/template/spec/volumes/-
+  value:
+    name: config-src
+    configMap:
+      name: settings
+- op: add
+  path: /spec/template/spec/initContainers
+  value:
+    - name: init-config
+      image: busybox:1.36
+      command: ["sh", "-c"]
+      args:
+        # SEED_VERSION history:
+        #   1 - initial configuration.yaml (default_config, http.trusted_proxies,
+        #       homeassistant.external_url)
+        [
+          "SEED_VERSION=1; if [ ! -f /dest/configuration.yaml ] || [ \"$(cat /dest/.seed-version 2>/dev/null)\" != \"$SEED_VERSION\" ]; then cp /src/configuration.yaml /dest/configuration.yaml && chmod +w /dest/configuration.yaml && echo \"$SEED_VERSION\" > /dest/.seed-version; fi",
+        ]
+      volumeMounts:
+        - name: config-src
+          mountPath: /src
+        - name: data
+          mountPath: /dest

--- a/kubernetes/apps/home-automation/homeassistant/patches/deploy-add-env.yaml
+++ b/kubernetes/apps/home-automation/homeassistant/patches/deploy-add-env.yaml
@@ -1,0 +1,5 @@
+- op: add
+  path: /spec/template/spec/containers/0/env
+  value:
+    - name: TZ
+      value: America/Boise

--- a/kubernetes/apps/home-automation/homeassistant/patches/deploy-config-mountpath.yaml
+++ b/kubernetes/apps/home-automation/homeassistant/patches/deploy-config-mountpath.yaml
@@ -1,0 +1,4 @@
+# pvc component mounts its volume at /data by default; HA expects /config.
+- op: replace
+  path: /spec/template/spec/containers/0/volumeMounts/0/mountPath
+  value: /config

--- a/kubernetes/apps/home-automation/homeassistant/patches/deploy-container-port.yaml
+++ b/kubernetes/apps/home-automation/homeassistant/patches/deploy-container-port.yaml
@@ -1,0 +1,3 @@
+- op: replace
+  path: /spec/template/spec/containers/0/ports/0/containerPort
+  value: 8123

--- a/kubernetes/apps/home-automation/homeassistant/patches/deploy-update-resources.yaml
+++ b/kubernetes/apps/home-automation/homeassistant/patches/deploy-update-resources.yaml
@@ -1,0 +1,13 @@
+# Learned from zigbee2mqtt: webapp/base's cpu: 10m default throttles
+# anything heavier than a static file server badly (see #90). HA is a
+# full Python app with a web UI + recorder DB — sized well above that
+# from the start rather than discovering it the same way again.
+- op: replace
+  path: /spec/template/spec/containers/0/resources
+  value:
+    limits:
+      cpu: "1"
+      memory: 1Gi
+    requests:
+      cpu: 250m
+      memory: 512Mi

--- a/kubernetes/apps/home-automation/homeassistant/patches/httproute-add-homepage-annotations.yaml
+++ b/kubernetes/apps/home-automation/homeassistant/patches/httproute-add-homepage-annotations.yaml
@@ -1,0 +1,10 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: route
+  annotations:
+    gethomepage.dev/enabled: "true"
+    gethomepage.dev/name: "Home Assistant"
+    gethomepage.dev/description: "Home automation"
+    gethomepage.dev/group: "Home Automation"
+    gethomepage.dev/icon: "home-assistant.png"

--- a/kubernetes/apps/home-automation/homeassistant/patches/svc-target-port.yaml
+++ b/kubernetes/apps/home-automation/homeassistant/patches/svc-target-port.yaml
@@ -1,0 +1,8 @@
+# Service stays on webapp/base's default port 8080 (matches what
+# httproute.yaml's backendRefs.port expects) — but HA's container
+# actually listens on 8123, so targetPort needs to be explicit; without
+# it, targetPort implicitly defaults to the same value as port (8080),
+# which would be wrong.
+- op: add
+  path: /spec/ports/0/targetPort
+  value: 8123

--- a/kubernetes/apps/home-automation/homeassistant/secret.yaml
+++ b/kubernetes/apps/home-automation/homeassistant/secret.yaml
@@ -1,0 +1,30 @@
+apiVersion: v1
+kind: Secret
+metadata:
+    name: mqtt
+type: Opaque
+stringData:
+    #ENC[AES256_GCM,data:jADY1DkVgg43BxNWEzKUTeBd0GTyhR4fEFTPlEUmmPVm+VAlyQCVPoivBQOiUxPNBr/PXifJ6fWch8xsC5YiAPU1auJG,iv:DwCHcZ3VfLanElWQBTnlPtoPieHSvKCEqtw9OHVqOJA=,tag:7B+VXug8r4nojOJz2kC9gg==,type:comment]
+    #ENC[AES256_GCM,data:u0wJs8AcLWHzyMUxDyWQXy+sJYEkQ91H1cQ5Z2D7+QmUUTu2BnCfUsJQHCjmAhE6R1yEbRQK5LyTT/FjjNXujl9ThKeL8Ro=,iv:qjXgnHf9tKOsj79K3FLpss5AukimBNZJRFz4wBzP2zE=,tag:1YS4tRmaeH5A9ElAijESVw==,type:comment]
+    #ENC[AES256_GCM,data:FR7vD16V4vEvRKlGjCDTSlRIEaxgVhlQoYzUmyOk0KI+BVU8ozKo+S9OI2e2YiEEh2wAH8kXpWu29I/Rxbo1pshxXqQIusg=,iv:fQLZOpqoM3Nb91+BriOeSccp253TJLNAl6NMCjWvM08=,tag:usR9lGFP0KpfdUMBNuAXYw==,type:comment]
+    #ENC[AES256_GCM,data:8Be0g/yUbwVBLtm7+gk/nAvHBSlGReXQwqJk+vhcgraocqTNLgt9PuS25Viym9u8tvA8ej11MCUEhOYrVk2z5g==,iv:16QaFuBXhzLyWH171ORAV10CJgtwYir/1+vxJhYOWRw=,tag:ei8Rb9NFyzzS9pl2yMj94Q==,type:comment]
+    #ENC[AES256_GCM,data:1jb6ewxghAHgwYp8ljaFbeLkriMmPLIesGf+F+6hEOp/u6++rJ67NuGhs4S3CFEFwOQce/WyGr82aBXicguQLe/dhD/3,iv:T++sc3/lp6ZMh/2kg4bYb1Omg/37BOJ60OzhHFHQg/U=,tag:BVrH1j2njMX30q6PPZHHMg==,type:comment]
+    #ENC[AES256_GCM,data:BNFcbMYK4i486PualIzUvXBb6DwemdVXzjKcuMgUmO57jItNIVPz5zcUkMftyQ==,iv:z7zcam6nXwQn089qf9ajzcV8f6BJX7LH8xq2EhPOC/I=,tag:BuT2JtHEwcBhStXAxnfeaw==,type:comment]
+    #ENC[AES256_GCM,data:pfJzHrP2f/0fx+eykeqpKNNkYe9LyWPZ+DLM51APnd/sx9Cv2yPXoljjroRHQ+hLQ7Pa0dFc2gUWx9aDWuncvZ+ot4be,iv:aHaaGW7sn3PkonriNFoftF68u6CWp/5cWDnlqRD+MnU=,tag:FgLoEKtQxvw29ipx8ZcUoA==,type:comment]
+    username: ENC[AES256_GCM,data:1LvRPF7kykPNSIKZGls=,iv:v/tkF9bIxOPyy0F8LJEj1cHahviliAqJiPqEiGBsbF0=,tag:C95ewQ2iwWlVGjsCiSJnlg==,type:str]
+    password: ENC[AES256_GCM,data:9RbNIpYBPRmTOBooepOUXQMzWFdmi+UJ,iv:LMcataLb9ScOgD6A/8/XTbManqqG8qDiWzoHrK4BJIE=,tag:FnpZCZwVYvekEH7DwHv/+A==,type:str]
+sops:
+    age:
+        - enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBKQitCSnVIcEZESTlmTnRh
+            ZGZJakd4TlRQd2Uzc0FzSmI3a1dCVUNESEVrCnN4VHhvUm5GeVJlNzQxbHllRmx0
+            c3RMKzVWNkQ5R09sdjI3azVJcDJkQUEKLS0tIG5XMytSOUNVQ1RaYlIvWnkyV2h6
+            UFJxektJZkx2bFdORVd0ZmNKdEV0NHMK1acPeNsWCpZTYENHVuNX8komH/13Zt1b
+            o1NfKVgeBb0IQY7GFy79bBCyb61UOP/aNldQ24p5q85OCFI06Rp4lw==
+            -----END AGE ENCRYPTED FILE-----
+          recipient: age13tszh09s5hr9hzjdy8enq7uncz9p2z09hsvky2dn25vudr4cx37s6k5n9z
+    encrypted_regex: ^(data|stringData)$
+    lastmodified: "2026-08-08T01:04:25Z"
+    mac: ENC[AES256_GCM,data:Hb5DO6kZk11LnpWLAk/UEHbSKuWEMveGQ4aXo+6xsB0fJnb6msshAc7YvpPHp8Fm/Gey3upWTSsCILD4mOTGmsL7RJPlcK69a9yaMlIkjpXJTvaEQRYktusAiMvP0ok1A1/8kFLy/b+x4wbIgnUK8U4qq+/OyXAiyhVSxgsAceA=,iv:VB6L4Sl8SVz4VjDVunMqDsUOr4g9NJtmP1S0cOlY2hA=,tag:kjtAjWCdsC8uFDSC3Pin0g==,type:str]
+    version: 3.13.0

--- a/kubernetes/apps/home-automation/mosquitto/configMap.yaml
+++ b/kubernetes/apps/home-automation/mosquitto/configMap.yaml
@@ -3,25 +3,20 @@ kind: ConfigMap
 metadata:
     name: mosquitto-base-config
 data:
-    mosquitto.conf: ENC[AES256_GCM,data:+JWKguiSE6z054ryvVDn/UkbVUPGRYxWQMpi4VaTQ69z1H1hrfIWIHeTe7bw6E/ct0rl/ekQj3T0CgoKmjJ74GajUN66YzEcxKbzcLhTfs28dq/CA89LEmuE/JLNM4TwHNuwC5fUmSD+obHkAToIOXGUhzcNGalLESyWea2rIFxKdOHfP5DrRak=,iv:By5xw16jK1W3v0M2fAACwMUSBcsDjsv42X9qjPFL23Y=,tag:aclJ/41CW//80JIdiDWRjQ==,type:str]
-    password_file: ENC[AES256_GCM,data:L/r1ocE4Lq9rZIr1S3vfWEW8tr5S9iJx69C254WnfEOS3wdyL1cidluxC1TWpuoOm0dBN5ZRigKcyD6meLSG+zIy4yzezJURYl3AJTFLIo3RVqFrhi9R6KO8wgcBMpCa331iIDhip5CmZUpy99PxGrUCguY0ylqQnzUKWzoZhxJ9qgORfCiGjBR6J7FGMqkcdTs6lI+3I4qWufW/fdLRirE+hRtBqJTjJD/uOruAuQ+HNO08DyBvrX/YZhnKe94loWbScgJKnKkAXyZxhyBpePmGZpMZIcUtiu4XUvEy2XuB4fOjSnFop4Uw8s4YC9qhto3KYK0sg5A+zVpLiPAj,iv:0bZUeiDU5aLW12ZK92XjyZN4LFOh2S7A8rxiQ4VN3iA=,tag:4dXX4qDQYieWPpCUPDIwOg==,type:str]
+    mosquitto.conf: ENC[AES256_GCM,data:BatVra9RT7bBqqxU2yTltwaGWP5UxfUB/LyeMK99062OcYxuDIHR02idKX52EPQMWMu7QhdGaEAl5Bmx5zjGSag653sV4vT5LYSjK6YkvoNDb9z3Bt6IGf2FHdNY2szFq8vv3prKBoQLk4jpJyaOx7l3GUmJXto3bSXUvOkt+lULOrs+45i6SoA=,iv:JAMiedwjQqfWmB0lWQJF+LSiJEUa6LM9NUE5pfVQ1yQ=,tag:nKZFGlofTIoNUwfu3kyHGw==,type:str]
+    password_file: ENC[AES256_GCM,data:X/6IiNcRA0ZpEUisvtQapHngodiasWVub49sJyfXYIQebZQvW35iP/IfTwrI9KaS7+bnwHaUJdSdYkyM1NbOj81ICresQ6gnfsosuh9pZqdupGn/Vn7AG89BlzUbamF2wSQBVMjjMv4tBPrXcHilhXbkbnECu9RQGRI8BAH//3QLXfTpU4E1g8kmT3Xrk+RV4HD6VI6JJfaq742FzVvo7bkg7E9Re2shr5F76yi7jfLWHANRdEThj7RNRcyvhaboYURCnkDDb8gUPe3Vb2pPQdBpXWAmvZ1Nq+Zmcv2YFB+Yv61jLKAVrXzChUU23KK4CaA1/yLCsp3vKk+4T6vh,iv:InqOCVdE0VzTHBgGCeo9lZbEGLs6ajCbNmTlygcCD5E=,tag:gdBxU8qV/g8NY2HITYy15Q==,type:str]
 sops:
-    kms: []
-    gcp_kms: []
-    azure_kv: []
-    hc_vault: []
     age:
-        - recipient: age13tszh09s5hr9hzjdy8enq7uncz9p2z09hsvky2dn25vudr4cx37s6k5n9z
-          enc: |
+        - enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBzQ1F3WFQzRE1VVExFeThv
-            VExmV2k4dTRJNGk0Q2QwM3lYSThucjdrcTJnCm9IMDVQMy9ZemRSaWFYUWpaV2FC
-            Zy8rMmJQRDJxcjk4OWZocFlHanlWWlEKLS0tIEovSWNHUmQzWVhuaUxXNUkyOFBO
-            ZlNQUnFlWGtwOFBCNUFKZ0JUWUljTGsKLUtt9+Phibjd+HI6PvtChnc2qHssqYtM
-            n7kk1isgv/8yL12GAkkwDwxkNNoLkP2T+95N274GFI9sLriHtmciDA==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBsaC9nT3ByQ0pFWnFhdm9N
+            eG5URWthbjE4T1F3OURkeWxDUUd4TXNNSWw4ClJ3dkt6azhWSFNVTmc2VFlhSDBD
+            WjVvL1F1TmVUc042S2xUVDRuTVl1V3cKLS0tIFFwRG9oU09ncFd6TmZnVVRMVmpR
+            eTNKZGRWMGlhM3Q1YVVGcXIzOVhTSFUKtP4rQXan76HFYTpnIgZ+/LvTZ5LLRarv
+            l7a9qiIclY3R1uLMV2D4vzGSTFXzplTtnkb6Fcxcb1G8MAff0HWExA==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2024-06-17T22:30:20Z"
-    mac: ENC[AES256_GCM,data:Tmh0iTHGb1h7eeZgmB6t7Rx2mFUiYyTCJwosN+u+wewwixQ5gC26zEDXG76KcFOPM7R2NfNAdSRi8ASlTcvt49RQSwEWlL4Q/UcWFadIB/8JvErO/AjiAhQvViBtjabcANLq9rxWqRpFdWL8grZOo12Oqt/Rktuar40BUgrCyyU=,iv:NpV5I4xv0Dw73WKnA+zrQ/3Q2lDScLV7pPHGcpXjgok=,tag:tctfgtllFLLlGdIKNYbUvw==,type:str]
-    pgp: []
+          recipient: age13tszh09s5hr9hzjdy8enq7uncz9p2z09hsvky2dn25vudr4cx37s6k5n9z
     encrypted_regex: ^(data|stringData)$
-    version: 3.7.3
+    lastmodified: "2026-08-08T01:03:09Z"
+    mac: ENC[AES256_GCM,data:Rp6w4qCimKLhjNKNZQVcHnqVXl7rN+W7MaFWq5n+F5I63lAsDicmNh+nGW5SUdxntuj0/rMn3E6f8kSIKjcdQhwwuD/QX5zy5YYW5FITi0RsGjz+HI+6SE4U0Hozk4sPBCIhAcN1RZdE+BrI/QTzNzUV1M9Ljbecw5ArFSQLJEs=,iv:wkgGn1psRskX5DgKL+BE1/VYy6WDFvwem9hK1EHnR2Y=,tag:/3LKbFrcAbwWrOirYiBltg==,type:str]
+    version: 3.13.0

--- a/kubernetes/apps/home-automation/mosquitto/deployment.yaml
+++ b/kubernetes/apps/home-automation/mosquitto/deployment.yaml
@@ -14,6 +14,13 @@ spec:
     metadata:
       labels:
         app.kubernetes.io/name: mosquitto
+      annotations:
+        # configMap.yaml is referenced by static name, not configMapGenerator,
+        # so content changes don't get a hash suffix that forces a rollout.
+        # The initContainer copies config unconditionally on every boot, so
+        # bumping this (any value, e.g. short description of what changed)
+        # is enough to roll the pod and pick it up.
+        home-lab-ops/config-generation: "2-hass-mqtt-user-password-rotated"
     spec:
       initContainers:
         - name: init-config

--- a/kubernetes/clusters/orion/home-automation.yaml
+++ b/kubernetes/clusters/orion/home-automation.yaml
@@ -33,3 +33,49 @@ spec:
         name: cluster-settings
       - kind: Secret
         name: cluster-secrets
+---
+# Separate Kustomization (not folded into home-automation above) so it
+# gets its own postBuild.substitute namespace — homeassistant/ uses the
+# webapp/base httproute/pvc components, which need ${appName}/${subdomain}/
+# ${storageClass}/${storageSize} substituted to different values than
+# zigbee2mqtt already claims above. One Kustomization = one flat
+# substitute namespace, so this can't share the one above. See
+# apps/home-automation/README.md. Same pattern as cert-manager.yaml /
+# gateway.yaml already use for co-located CRs — kept in this file rather
+# than a new one since they're logically the same app group.
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: homeassistant
+  namespace: flux-system
+spec:
+  dependsOn:
+    - name: cilium
+    - name: gateway
+    - name: cert-manager-issuers
+    - name: cluster-settings
+    - name: home-automation
+  interval: 1h
+  retryInterval: 1m
+  timeout: 5m
+  prune: true
+  wait: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+  path: ./kubernetes/apps/home-automation/homeassistant
+  decryption:
+    provider: sops
+    secretRef:
+      name: sops-age
+  postBuild:
+    substitute:
+      appName: homeassistant
+      subdomain: ha
+      storageClass: rook-ceph-block
+      storageSize: 10Gi
+    substituteFrom:
+      - kind: ConfigMap
+        name: cluster-settings
+      - kind: Secret
+        name: cluster-secrets


### PR DESCRIPTION
Adds Home Assistant, using the lessons from the zigbee2mqtt rollout earlier today (#88–#94) rather than re-learning them.

## Architecture

`kubernetes/clusters/orion/home-automation.yaml` now holds **two** Flux Kustomization CRs (`---`-separated in one file — same pattern `cert-manager.yaml`/`gateway.yaml` already use):
- `home-automation` → mosquitto + zigbee2mqtt (unchanged)
- `homeassistant` → `./kubernetes/apps/home-automation/homeassistant` directly

Kept as a separate CR rather than added to the aggregator: one Flux Kustomization = one flat `postBuild.substitute` namespace, and `zigbee2mqtt` already claims `${appName}`/`${subdomain}`/`${storageClass}`/`${storageSize}` — the vars the shared `httproute`/`pvc` components rely on. A second component-based consumer in the same Kustomization would silently resolve both apps' vars to whichever value happened to be set last, not fail loudly. Separate CR = separate substitute namespace = both apps get full use of the shared components. Full writeup in `apps/home-automation/README.md`.

`homeassistant/` still lives inside `apps/home-automation/` and shares its `home-automation` namespace, so it can reach `mosquitto` by short name.

## What's in the app

- Built on `../../webapp/base` + `httproute`/`pvc` components, same as `zigbee2mqtt`.
- Container port 8123 (HA's real port); Service stays on port 8080 (matches what the `httproute` component expects) with `targetPort: 8123`.
- `pvc` component mounts at `/data` by default — patched to `/config` (HA's expected path).
- Seed `configuration.yaml` → PVC via the same `SEED_VERSION`-marker initContainer pattern `zigbee2mqtt` uses (see #94) — re-seeds only when the version changes, safe against clobbering HA's own runtime state (recorder DB, `.storage/`) once that exists.
- Resources set well above `webapp/base`'s `cpu: 10m` default **from the start** (`1` cpu / `1Gi` mem limit) — no reason to rediscover #90's CPU-throttling issue on an app heavier than zigbee2mqtt.
- Seed config sets `http.trusted_proxies: 10.241.0.0/16` (orion's actual pod CIDR, from `talconfig.yaml`) — HA rejects requests through a reverse proxy without this — and `homeassistant.external_url`.

## MQTT credential

`mosquitto`'s `hass_mqtt_user` password was provisioned na-era but the plaintext was never recoverable (mosquitto only stores the hash) — regenerated it locally (same `eclipse-mosquitto:2.0.18` image, offline, no cluster access) and recorded the new plaintext in `homeassistant/secret.yaml` (SOPS) for retrieval. `mosquitto/deployment.yaml` picked up a bumped `home-lab-ops/config-generation` annotation to force the rollout needed to actually load it — mosquitto's `ConfigMap` is referenced by static name, not `configMapGenerator`, so a content-only change doesn't trigger a restart on its own.

## What still needs a human

Home Assistant's own onboarding (create the admin account, name the instance) isn't config-file-representable — visit `ha.${domain}` once after this reconciles. After that, add the MQTT integration via *Settings → Devices & services → Add integration → MQTT* using the credentials in `homeassistant/secret.yaml`; zigbee2mqtt is already publishing `homeassistant/...` discovery topics, so paired devices should show up automatically.

## Verification

- `task gen:validate` / `task test:build` — clean, 19/19 (up from 18 with the new Kustomization).
- Confirmed via the actual rendered output that the `pvc` component's volume and this app's own `config-src` volume append correctly (no clobbering) — same check I ran when `zigbee2mqtt` first went onto these components.
- Not yet verified against the live cluster.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Home Assistant to the home-automation stack with persistent storage, web access, timezone settings, resource configuration, and homepage integration.
  * Added MQTT credentials and configuration for Home Assistant.
  * Added versioned configuration seeding to preserve customized settings while applying updates.
  * Added automated deployment updates when Mosquitto credentials change.

* **Documentation**
  * Expanded setup, onboarding, MQTT integration, credentials, configuration, and troubleshooting guidance for the shared home-automation stack.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->