### PR TITLE
fix: seed HA's http config via .storage, not YAML

### DIFF
--- a/kubernetes/apps/home-automation/README.md
+++ b/kubernetes/apps/home-automation/README.md
@@ -77,10 +77,19 @@ pattern's kept consistent).
   2.x — toggle it via the frontend or
   `zigbee2mqtt/bridge/request/permit_join` (`{"value": true}`) when
   pairing new devices, not in git.
-- Home Assistant's seed config sets `http.trusted_proxies:
-  10.241.0.0/16` (orion's pod CIDR, from `talconfig.yaml` — required or HA
-  rejects requests coming through the Gateway) and
-  `homeassistant.external_url`. Resource limits are set well above
+- Home Assistant's reverse-proxy trust (`use_x_forwarded_for` /
+  `trusted_proxies: 10.241.0.0/16`, orion's pod CIDR from `talconfig.yaml`)
+  is seeded via `.storage/http` (`homeassistant/configMap.yaml`'s
+  `http-storage.json` key), **not** `configuration.yaml`'s `http:` block.
+  HA stages YAML `http:` config as an unconfirmed "pending" trial that
+  auto-reverts (and restarts) if nothing promotes it within 5 minutes of
+  boot — fine if a human's watching the UI, impossible for an unattended
+  GitOps deploy, and once it fails the trial it's marked "never retry" and
+  won't self-heal on the next restart either. Seeding storage directly,
+  pre-marked `stable`, skips the trial. Also matches where upstream is
+  headed anyway: YAML `http:` config is deprecated as of this HA version,
+  breaking entirely in 2027.2.0. `homeassistant.external_url` still comes
+  from `configuration.yaml` as normal. Resource limits are set well above
   `webapp/base`'s defaults from the start (`1` cpu / `1Gi` mem limit) —
   zigbee2mqtt's `webapp/base` default of `cpu: 10m` throttled it badly
   (#90); no reason to rediscover that here.
@@ -105,10 +114,14 @@ pattern's kept consistent).
   `mosquitto/configMap.yaml`'s `password_file`.
 - **Zigbee2MQTT can't reach the coordinator:** confirm the SLZB-06 is up at
   `10.50.0.150` and its ser2net port hasn't moved from `6638`.
-- **Home Assistant rejects requests / login weirdness behind the Gateway:**
-  check `http.trusted_proxies` in the seeded `configuration.yaml` still
-  covers the pod CIDR (`kubectl get ciliumnode` or `talconfig.yaml` if it's
-  ever changed).
+- **Home Assistant rejects requests / login weirdness behind the Gateway,
+  or logs "A request from a reverse proxy was received... not set-up for
+  reverse proxies":** check `.storage/http`'s `stable.trusted_proxies`
+  (not `configuration.yaml` — see above) still covers the pod CIDR
+  (`kubectl get ciliumnode` or `talconfig.yaml` if it's ever changed). If
+  this shows up on a pod that's been running a while, HA's own pending-config
+  trial (see above) may have reverted a change — check for `pending` in
+  `.storage/http` with `"error": "not_promoted"`.
 - **Config change not taking effect on an already-running pod:** see the
   seed-config pattern above — bump `SEED_VERSION` (zigbee2mqtt/homeassistant)
   or `home-lab-ops/config-generation` (mosquitto).

--- a/kubernetes/apps/home-automation/homeassistant/configMap.yaml
+++ b/kubernetes/apps/home-automation/homeassistant/configMap.yaml
@@ -3,19 +3,29 @@ kind: ConfigMap
 metadata:
     name: settings
 data:
-    configuration.yaml: ENC[AES256_GCM,data:5xuLQWSKgOhGbAkZgMt29Mch0LXuraxfWLMlI8FDLRVFeouEZ2MJTfHcPRtYV/GORboiDrc0WDH2FNq0s8vEraiJvzIVVpvK1ixOo/b5+VDrlYuImSt+GpA3ZH2uy9pFVTJqshRdRv7WnLI2tnBP6FxPIe/46qxaVuLiI0sJIqva6wJ/sVTfEESCNk4yH5SLZheTxekkzoWO,iv:bkmZIlYjCwHBjEH9kTHeWVj8qnyt1js8opYALYDjtpg=,tag:8H6Foq9QAaEFxuKPNNEcBA==,type:str]
+    configuration.yaml: ENC[AES256_GCM,data:M4NajFjVKiO5AJqDV/BBvt/2yCZPuTT/0MnRdaPKRPTajNa96ievHo7PxLaP8bi3b3CV4Ge1SCRgsB/yelf6e2QFwaPpWpKgkbvVf8pGIJQ=,iv:O+ENFkRMqMX5Ba2YNLiiZFS4n7iXjxF6KJYGuvXoHgE=,tag:6oSApaaf3hMDo543nDL63w==,type:str]
+    #ENC[AES256_GCM,data:uC5P0Fs416azdDllbnNdbv4H0ufaOUp3B6fWCbF4wzFIvUggcHb0k64W3XbK60CrdLup65RKs1DyrB9M5uMOg28rJQMeRr9rOg==,iv:nZ+3fh9szCMbqRvWRzJYJa50AOwXOI8lutvFo0CqE5w=,tag:By4K2yMPTlDJ8xaxFFRayA==,type:comment]
+    #ENC[AES256_GCM,data:bLMqK0lM0DbAPs01jRkpQwwXO6RGD3wnNCL2lqA4Zhp9ItLcY76BH+6osZlYzZh+d3D11fdeFNGfNbRJosRPH9M=,iv:Q+oa0m5vgIWspXp0A/CPRoIEc1sdcfciVM77BTPcth8=,tag:GFfQhfdQFA5oPZ7XfRuy6Q==,type:comment]
+    #ENC[AES256_GCM,data:NV/6VdEvEA5nbxWPDPwFbD/hST8l6Kfg46Y5THoa+YhMlZYIZRabqiCmr6HiPGOfW9yQ6Cq/UMdSs61BYR6yLpz7WFLI,iv:tV4oyrYUKu1N4B33f74tP8MDenoPVjvHu96LH+Q+Y+4=,tag:H54ziC8UBtLYho4XdHU5lQ==,type:comment]
+    #ENC[AES256_GCM,data:T4mOIhi66B7gJtAJPRqTAiwIcx4N3nnO/Ngbif5fZQV224DAHs4WpRm7iIwEGGuEx2Y2abqUBSWzF3C5j5CLUWdVvKk=,iv:Yweg/+2b7reOhW7Jij1epoCc+KYwpZHPrr/Np5wuTlI=,tag:W5XpDRkTp9Kv+ACCG1b6ug==,type:comment]
+    #ENC[AES256_GCM,data:i531NjXVd7wFUDItXrUac1OHsuVFOpC3Ol9rhM/tosS3MpEIRRqipzMkCsUOuvy25EqbHO0FW9+cYYkPuLvInTFn3DaxPw==,iv:afaWcavozfjFg9/wp4MBelmrFyveP5+soxzzyjmBIoo=,tag:ztV7OYsVcxKJYxKkGOsBPw==,type:comment]
+    #ENC[AES256_GCM,data:Ys7GuwNvEkpI+1x+1/kWZI14/CTFED5hW3DoqdUzPN4tfTfjrdpjPWk2f+1diHX34PXbyhInQ4+DddCx1uc/VdGx51yA+A==,iv:phUnYit/p9Gi6So56Ki+OEYNjt7qKRU4xNad1ftBAbo=,tag:GWaSVgHFJNsUreO58U6pzQ==,type:comment]
+    #ENC[AES256_GCM,data:wWI0zDrvF1/2QLuPcl9YN5NCERk9ivkyRYV3E+X1XH3ZkRqn1EM2LvakMnws/gUHfubglyild5xOAn2SixenSQk=,iv:3H2LXgCYAPin1fq3OCZ6R7iBxBU7rgQkMhWfGDA9wMg=,tag:/ObJhnSaq8I0rEcYJem4jA==,type:comment]
+    #ENC[AES256_GCM,data:CBWSKJFf3B9gyuhjPSt75mrOt3j6vP1hIW2a4V5VzNppXnscpj8X3vFFoRrUuaEWGPwPlSs15MvkfKUMGk+1OoAgGoh9,iv:ALs3SCPUypb7fPkYZD3lJ4fZcOY8P+4nJ+hJ+oCdsyg=,tag:rZsIALzcDeuaAiVSFqqsmQ==,type:comment]
+    #ENC[AES256_GCM,data:rsed7SNILGK0j7rn/E/GZ9sw8pLHHV5FzoQ=,iv:DomgI6PkHdusPBmkQagok+nmzHKOJZYkFcGGooLBonE=,tag:Jde9NU6Q7TilXlAE+w/R3g==,type:comment]
+    http-storage.json: ENC[AES256_GCM,data:UUd5M41xRv4upuy9B7Hb2io+/RW7uaGdQzk5QbjhTI40+mgMFXxNpOcXV0kDbdwt4mTUznIsGXWzobCy7p4+LLbtWFZuODOjcBaQ1JODrsAWl0jhxbuy5YnamCaKIKFMEU1cvJ51nqFHWjy4+met0LzXcaFLOek9UokJugQC4MSL0tM8P8vQ31HoRvf04Ea1Sk7HvGMc6Avq4j9hc3Nh3apmqnHra/g1Qkin9xOblHXkI4YnkyFD/rSCy7SerJ0hBIt2ZJnQVOImIL6lKthlS0wDnjmCTfKG9Q6zl16L3TQUkmPeDF0mlTRwucePFOOB73ThMtAjJfouBUOcb/BJ10B1eUgspdhoE/9ji+MRdnFJG3rvBiSTGc5Yb1cR0ha4QjdEL8bx4z/Zq16wrjeoaKlI0M+D/MC4VA0Wc0b17BsxEehKmh+KkHxL1Cdng5hBDbdWU7BqHjb5T80QMhE9ZkUYVayPQnoDDPLpbj334hrOkhIkmHxmvJrtYkTQe8o8crCZRR5t4T6nKwK8JT+Jlt0tL+9EOJLAzIE3OjiRL2zU3dSMyyuJSqrDwUL2QDQ5gd8f673SD3hBFCMeYo5fLjDshZ4sEqQbFkBmrQQfqff2cbMMuNy3O5StkeEw7acUKMPvpjPtUfH5NPgBRixC1ReK+uU0uJC0MyyY/Mwy8FIF2Hbtj3rIouko3wF9sAu2khEGxWJMDe67kttmQA25Dq9B/qeCJaTSqxDErrHeMr23jw==,iv:m0ZLvvFFasra+Pehu8/Re2buA9DNBUtzsKSF8SIK7Gg=,tag:1DsidfA4hJAH5ZSJkPHpjQ==,type:str]
 sops:
     age:
         - enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSB4cUx4YlVDWktCdW8zT3lm
-            anF0QzQrNnhJbXRDamx0VUNUdHNGNTlIZ0MwCmFmTk9KWWMxRy9Zc05TZW5FVDlW
-            R0t2VlFlMkUxUGwzYkhVbnlPNzhGZzgKLS0tIEljaWtubkE5Y0podFZlMXZtd2Yr
-            QWF4aWtPVVRDN3BrM1drVUJoWkwzQ3cKajmvNpuVQwLv6RsfPkh5Vr8SkqfLnpWN
-            qqIFVkrb8gR8HpiO2CKF9+0/KIZEOqSgbPQBiVTBO25URQ6sxpbxEw==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBsRmZpUnhqNmtjbkhZb0RG
+            bGNCdlRtT3BiOHpOYlpLNURNellmeEo3SVFBCjBNS3JnTGhlS2dhZS9BMmNLc0th
+            dWt6RmxIK1RLaUY2ZUxUOFZHbXpuYVEKLS0tIHZYWmd3SDdjQnp4ODBiZFVmSTFo
+            SVo4RVNzbE9ES2dMblRXb2grazVzTVEKHHcxB/ZhgNFzWx1IHu4lwhrs2hQM8bmM
+            gNSyKxVjoB0/6kVKoygi1rlo7xFBl7vJKFywAaxLnKsPd+wQnE5kIA==
             -----END AGE ENCRYPTED FILE-----
           recipient: age13tszh09s5hr9hzjdy8enq7uncz9p2z09hsvky2dn25vudr4cx37s6k5n9z
     encrypted_regex: ^(data|stringData)$
-    lastmodified: "2026-08-08T01:04:11Z"
-    mac: ENC[AES256_GCM,data:LThPruADmd84jZ1KYrAk5ygoxboe4kC70K0hjQNPB7XNdqGZZO690TLR4gjgTg/ehTa6ivh0uKhk4Gyp0RM3/snGLJP343Ri7BKYBlcu6lQYeEqaTGAZSwfQ98Z9DaVUFHIB1DYo9c1LJMCAc694E18nTbgqbIFR+0YQtpFFwo4=,iv:fmT91z2cyLO0kL1RJRf4082XxcXUlRoi2WN/tojRVEs=,tag:f2koUipy6mVvPbR4vKq6NA==,type:str]
+    lastmodified: "2026-08-08T01:41:53Z"
+    mac: ENC[AES256_GCM,data:eoSJGiHzngXGcYLVxAQoUZLtMT83oTwgq7RQn8aiJu1Xlf4lP+8FvjCbcfqji4MOL41o8emwXbMiBHIaIy8dDRht/CLs+zLcji04r0VdthU/fRmWOiCEmxhhtRGRGPWf6ydMOnVf0qmHxQfX2mnHX5+aTzd5Mdk+6MhMJtAb+lQ=,iv:7zfOIul43eAoUNSUVuHiCXwjG+AOlF3zDoiUhXGYCEM=,tag:svm2mm9Cggp1COgYOvv8Bg==,type:str]
     version: 3.13.0

--- a/kubernetes/apps/home-automation/homeassistant/patches/deploy-add-config-init.yaml
+++ b/kubernetes/apps/home-automation/homeassistant/patches/deploy-add-config-init.yaml
@@ -19,8 +19,14 @@
         # SEED_VERSION history:
         #   1 - initial configuration.yaml (default_config, http.trusted_proxies,
         #       homeassistant.external_url)
+        #   2 - moved http.* out of configuration.yaml into .storage/http,
+        #       pre-marked "stable" — HA stages YAML http: config as an
+        #       unconfirmed "pending" trial that auto-reverts if nothing
+        #       promotes it within 5 minutes of boot (fine interactively,
+        #       impossible for an unattended deploy); seeding storage
+        #       directly, already confirmed, skips that trial entirely.
         [
-          "SEED_VERSION=1; if [ ! -f /dest/configuration.yaml ] || [ \"$(cat /dest/.seed-version 2>/dev/null)\" != \"$SEED_VERSION\" ]; then cp /src/configuration.yaml /dest/configuration.yaml && chmod +w /dest/configuration.yaml && echo \"$SEED_VERSION\" > /dest/.seed-version; fi",
+          "SEED_VERSION=2; if [ ! -f /dest/configuration.yaml ] || [ \"$(cat /dest/.seed-version 2>/dev/null)\" != \"$SEED_VERSION\" ]; then cp /src/configuration.yaml /dest/configuration.yaml && chmod +w /dest/configuration.yaml && mkdir -p /dest/.storage && cp /src/http-storage.json /dest/.storage/http && chmod +w /dest/.storage/http && echo \"$SEED_VERSION\" > /dest/.seed-version; fi",
         ]
       volumeMounts:
         - name: config-src


### PR DESCRIPTION
Follow-up to #95 — onboarding was 400ing:

\`\`\`
ERROR [homeassistant.components.http.forwarded] A request from a reverse
proxy was received from 10.241.3.192, but your HTTP integration is not
set-up for reverse proxies
\`\`\`

Confirmed on the live pod that \`configuration.yaml\` was byte-exact correct (\`use_x_forwarded_for: true\`, \`trusted_proxies: [10.241.0.0/16]\`, which does cover \`10.241.3.192\`) — so this wasn't a config content mistake.

## Root cause

Traced through \`homeassistant/components/http/config.py\` at the actual running version (\`2026.8.1\`, released the same day I built this). YAML \`http:\` config isn't applied directly anymore — it's staged as an unconfirmed **pending trial** that must be promoted via the UI within 5 minutes of boot, or it auto-reverts to \`stable\` (bare defaults, since this was a first-ever boot with nothing previously confirmed) and restarts. Confirmed exactly this in the live pod's own logs:

\`\`\`
WARNING [homeassistant.components.http.config] Pending HTTP config was not
confirmed within 0:05:00; reverting to the stable config and restarting
\`\`\`

Nobody was watching the UI within 5 minutes of an unattended GitOps pod boot, so it reverted. Worse: per the same source, a pending config that fails its trial gets marked with an error and is **never retried automatically** — a plain pod restart doesn't fix it either.

## Fix

Seed \`.storage/http\` directly (new \`http-storage.json\` ConfigMap key), pre-marked \`stable\` with \`yaml_migration_done: true\` — skips the trial/confirmation dance entirely. Dropped the \`http:\` block from \`configuration.yaml\` to match, which also happens to be the direction upstream is already headed: YAML \`http:\` config is deprecated as of this version and breaks entirely in \`2027.2.0\` per the same source file.

Traced every field's exact shape/defaults through \`HTTP_STORAGE_SCHEMA\` rather than guessing (default CORS origins, login attempts threshold, SSL profile, etc.), and validated the constructed JSON actually parses before committing it.

\`SEED_VERSION\` bumped \`1\` → \`2\` so this re-seeds the already-live PVC's stale v1 state (old \`http:\` block, no \`.storage/http\` at all yet).

## Verification

- Tested the re-seed shell condition standalone against the live pod's *exact* current state (v1 marker present, no \`.storage/\`) plus fresh-PVC and already-current-version cases — all four correct.
- \`task gen:validate\` / \`task test:build\` — clean, 19/19.
- Diagnosis was read-only \`kubectl\` only (\`logs\`, \`exec cat\`/\`python3 -c\` to inspect and parse the live file) — no direct cluster changes.
- Not yet re-verified against the live cluster post-merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)