### PR TITLE
chore: move opensprinkler and neurio to Home Automation on homepage

### DIFF
--- a/kubernetes/apps/external-endpoints/neurio/httproute.yaml
+++ b/kubernetes/apps/external-endpoints/neurio/httproute.yaml
@@ -6,7 +6,7 @@ metadata:
     gethomepage.dev/enabled: "true"
     gethomepage.dev/name: "Neurio"
     gethomepage.dev/description: "Home power monitor"
-    gethomepage.dev/group: "Energy"
+    gethomepage.dev/group: "Home Automation"
     gethomepage.dev/icon: "neurio.png"
 spec:
   parentRefs:

--- a/kubernetes/apps/external-endpoints/opensprinkler/httproute.yaml
+++ b/kubernetes/apps/external-endpoints/opensprinkler/httproute.yaml
@@ -6,7 +6,7 @@ metadata:
     gethomepage.dev/enabled: "true"
     gethomepage.dev/name: "OpenSprinkler"
     gethomepage.dev/description: "Irrigation controller"
-    gethomepage.dev/group: "Home"
+    gethomepage.dev/group: "Home Automation"
     gethomepage.dev/icon: "opensprinkler.png"
 spec:
   parentRefs:


### PR DESCRIPTION
Regroups OpenSprinkler and Neurio from "Home" / "Energy" into "Home Automation" on the homepage dashboard — annotation-only change, no routing/namespace impact.

Verified with \`task test:build\` (20/20 pass).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Reclassified the Neurio homepage under **Home Automation**.
  * Reclassified the OpenSprinkler homepage under **Home Automation**.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->