### PR TITLE
fix: add missing homebox Namespace resource

### DIFF
--- a/kubernetes/apps/homebox/kustomization.yaml
+++ b/kubernetes/apps/homebox/kustomization.yaml
@@ -5,6 +5,7 @@ namespace: homebox
 
 resources:
   - ../webapp/base
+  - namespace.yaml
 
 namePrefix: homebox-
 

--- a/kubernetes/apps/homebox/namespace.yaml
+++ b/kubernetes/apps/homebox/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: homebox


### PR DESCRIPTION
Follow-up to #99. `homebox` set `namespace: homebox` in the kustomization but never created the `Namespace` object itself (pihole/home-automation both do, via a `namespace.yaml` resource — homebox never had one). Flux can't apply into a namespace that doesn't exist, which is the "namespace not found" error hit after #99 merged.

This fix was actually pushed to `feat/homebox-orion` before #99 merged, but #99 was merged from an earlier commit on that branch and never picked it up — cherry-picked (`2f3cc50`) onto `main` here instead.

Verified: `task test:build` passes (20/20); namespace renders with the `httproute` component's `gateway.networking.k8s.io/access: "true"` label as expected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)