### PR TITLE
fix: homebox 0.26.2 requires HBOX_AUTH_API_KEY_PEPPER at boot

### DIFF
--- a/kubernetes/apps/homebox/kustomization.yaml
+++ b/kubernetes/apps/homebox/kustomization.yaml
@@ -6,6 +6,7 @@ namespace: homebox
 resources:
   - ../webapp/base
   - namespace.yaml
+  - secret.yaml
 
 namePrefix: homebox-
 

--- a/kubernetes/apps/homebox/patches/deploy-add-env.yaml
+++ b/kubernetes/apps/homebox/patches/deploy-add-env.yaml
@@ -3,3 +3,8 @@
   value:
     - name: TZ
       value: America/Boise
+    - name: HBOX_AUTH_API_KEY_PEPPER
+      valueFrom:
+        secretKeyRef:
+          name: homebox-auth
+          key: apiKeyPepper

--- a/kubernetes/apps/homebox/secret.yaml
+++ b/kubernetes/apps/homebox/secret.yaml
@@ -1,0 +1,22 @@
+apiVersion: v1
+kind: Secret
+metadata:
+    name: auth
+type: Opaque
+stringData:
+    apiKeyPepper: ENC[AES256_GCM,data:xJqVe0xTaI1NOs4jprtZifWSXaB8BKXmMODFgRqDoiYmuQVc8xpb6PsQUA2ezeQZv7HoZsy1bs/+7MCWBnrW7A==,iv:PKf6zPPCM86qp3shIY35qlyV1RwMRdypvLiUxL7VUZY=,tag:lLctqiHnthbyFezaN6aWhw==,type:str]
+sops:
+    age:
+        - enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBaS2RXQlRoWXVaajB4WjFi
+            U28xbzl5OXhxWlhNYVRrVWpKRkRSSENoUXpRCkwzN0dOM1lsNG14K0lHQ0s0ZFRE
+            RStocmczaXI3akp4WnlHN2VvYmhXZ2sKLS0tIDFZWExEOFZQQjZFdDBVYlIwc25F
+            Q1pTN3kwZ0pXUWRVNkFRSzgrd3k0bmsKtq7eA7O1fl6Naw3lih4vJRRYrArNDZko
+            8wuFP4ms7q3fttZb5qrZ7d/uM8WU+CMwuTHr9zA4jFvfCNutM1tDBw==
+            -----END AGE ENCRYPTED FILE-----
+          recipient: age13tszh09s5hr9hzjdy8enq7uncz9p2z09hsvky2dn25vudr4cx37s6k5n9z
+    encrypted_regex: ^(data|stringData)$
+    lastmodified: "2026-08-08T04:21:40Z"
+    mac: ENC[AES256_GCM,data:ey5dsiq/ZagoRd36wpwcDPpXcZfL34PwKpNIFEeH2Lpn/Zfi1gNt4r98xZtvHGHE6iu1MbEWe+ma+PXzY3585VZrx7PScPxMDsb3THIkrh3XRB+rr05ZKnRV/MGeu8WgnpzKoZ9Y6m5hBjEfxpVZNo13E31wVon+cbphlC5eftE=,iv:06+06PsM/1y/x9kqhMMGhIVRm7VzuW6VKjYfIqwSxZk=,tag:BSSD8NDiBYgRFySG/4N58w==,type:str]
+    version: 3.13.0


### PR DESCRIPTION
Root cause of the "upstream connect error" on homebox: the pod is crashlooping.

\`\`\`
panic: auth.api_key_pepper must be set to at least 32 bytes; generate with `openssl rand -base64 48` and provide via HBOX_AUTH_API_KEY_PEPPER. Rotating it invalidates all issued API keys
\`\`\`

homebox `0.26.2` (bumped from `0.20.2` in #99) enforces this at startup; the old tag didn't need it, so it was never in the env. Confirmed via `kubectl logs -n homebox --previous` against orion (read-only).

- `secret.yaml` — sops-encrypted, `apiKeyPepper` generated with `openssl rand -base64 48`
- wired into the container via `secretKeyRef` (`homebox-auth` / `apiKeyPepper`) → `HBOX_AUTH_API_KEY_PEPPER`

Verified: `task test:build` passes (20/20); rendered manifest confirms the Secret name (`homebox-auth`, post `namePrefix`) matches the `secretKeyRef` in the Deployment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)