### PR TITLE
chore: homebox homepage group -> Inventory

### DIFF
--- a/kubernetes/apps/homebox/README.md
+++ b/kubernetes/apps/homebox/README.md
@@ -15,7 +15,7 @@ the `httproute` and `pvc` components — canonical example for `apps/webapp/`.
 
 Exposed via the `httproute` component at `${subdomain}.${domain}`
 (`inventory.orion.norseamerican.com`). gethomepage.dev annotations on the
-route surface it on the dashboard under "Home".
+route surface it on the dashboard under "Inventory".
 
 ## Troubleshooting
 

--- a/kubernetes/apps/homebox/patches/httproute-add-homepage-annotations.yaml
+++ b/kubernetes/apps/homebox/patches/httproute-add-homepage-annotations.yaml
@@ -6,5 +6,5 @@ metadata:
     gethomepage.dev/enabled: "true"
     gethomepage.dev/name: "Homebox"
     gethomepage.dev/description: "Home inventory management"
-    gethomepage.dev/group: "Home"
+    gethomepage.dev/group: "Inventory"
     gethomepage.dev/icon: "homebox.png"


### PR DESCRIPTION
Regroups homebox from "Home" (leftover from the webapp README's example) to its own "Inventory" group on the homepage dashboard — annotation-only change.

Verified with \`task test:build\` (20/20 pass).

🤖 Generated with [Claude Code](https://claude.com/claude-code)