### PR TITLE
fix: homebox CPU throttling on registration (503)

### DIFF
--- a/kubernetes/apps/homebox/kustomization.yaml
+++ b/kubernetes/apps/homebox/kustomization.yaml
@@ -35,6 +35,10 @@ patches:
       name: deploy
     path: patches/deploy-add-env.yaml
   - target:
+      kind: Deployment
+      name: deploy
+    path: patches/deploy-update-resources.yaml
+  - target:
       kind: Service
       name: svc
     path: patches/svc-target-port.yaml

--- a/kubernetes/apps/homebox/patches/deploy-update-resources.yaml
+++ b/kubernetes/apps/homebox/patches/deploy-update-resources.yaml
@@ -1,0 +1,13 @@
+# webapp/base's cpu: 10m default throttles anything heavier than a static
+# file server (see #90 — zigbee2mqtt hit the same thing on boot). Here it
+# surfaced as registration hanging then 503ing: bcrypt password hashing
+# is a CPU burst 10m can't service in a reasonable time.
+- op: replace
+  path: /spec/template/spec/containers/0/resources
+  value:
+    limits:
+      cpu: 500m
+      memory: 512Mi
+    requests:
+      cpu: 100m
+      memory: 256Mi


### PR DESCRIPTION
Registration was hanging in the browser and eventually returning 503. Same root cause as #90 (zigbee2mqtt): `webapp/base`'s `cpu: 10m` default is fine for a static file server, not for a real CPU burst — here, bcrypt password hashing during account creation.

Sized similarly to zigbee2mqtt (both lightweight compiled binaries — Go here, Node there — not HA's heavier Python stack): `100m/256Mi` request, `500m/512Mi` limit.

Verified: `task test:build` passes (20/20); rendered manifest confirms the new resources block replaces the base 10m/500Mi.

🤖 Generated with [Claude Code](https://claude.com/claude-code)