### PR TITLE
feat: add DGX Spark (orion-ai-01) as arm64 GPU worker

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -6,6 +6,8 @@ brew "sops"
 brew "fluxcd/tap/flux"
 
 # Talos
+# keep talhelper current — old builds silently drop newer Talos config
+# fields (e.g. Layer2VIPConfig) instead of erroring
 brew "talhelper"
 brew "talosctl"
 

--- a/clusters/orion/patches/nodes/orion-ai-01.yaml
+++ b/clusters/orion/patches/nodes/orion-ai-01.yaml
@@ -1,0 +1,26 @@
+machine:
+  certSANs:
+    - 10.50.0.31
+    - orion-ai-01.norseamerican.com
+  install:
+    wipe: true          # replace DGX OS outright — no leftover GPT/ESP
+    grubUseUKICmdline: false   # required: incompatible with extraKernelArgs below
+    extraKernelArgs:
+      - arm64.nobti     # kept for good measure; actual effect comes from the schematic-baked installer
+  # Requires arm64.nobti (baked into the schematic in talconfig.yaml) or the
+  # node crash-loops loading these — machine.install.extraKernelArgs alone is
+  # a no-op on this hardware's systemd-boot/UKI path.
+  kernel:
+    modules:
+      - name: nvidia
+      - name: nvidia_uvm
+      - name: nvidia_drm
+      - name: nvidia_modeset
+  nodeLabels:
+    nvidia.com/gpu.present: "true"
+  # nodeTaints deliberately NOT used: Kubernetes' NodeRestriction admission
+  # plugin forbids a node from modifying its own .spec.taints after initial
+  # creation. Talos's k8s.NodeApplyController runs post-creation and always
+  # gets rejected here — it also bundles this with the nodeLabels PATCH,
+  # which then fails atomically too. Taint is set via `kubectl taint` instead
+  # (admin credentials, not subject to NodeRestriction) — see runbook memory.

--- a/clusters/orion/talconfig.yaml
+++ b/clusters/orion/talconfig.yaml
@@ -176,3 +176,39 @@ nodes:
               - 10.10.0.22/24
     patches:
       - "@./patches/nodes/orion-w-02.yaml"
+
+  # ── AI/GPU nodes ───────────────────────────────────────────────────────────
+  # Hardware: NVIDIA DGX Spark (GB10, arm64) — onboard RJ45 is enP7s7
+
+  - hostname: orion-ai-01
+    ipAddress: 10.50.0.31
+    controlPlane: false
+    installDiskSelector:
+      serial: S8C2NG0YA00300
+    schematic:
+      customization:
+        # arm64.nobti baked into the installer itself — machine.install.extraKernelArgs
+        # is a no-op on this hardware's systemd-boot/UKI path (confirmed via
+        # /proc/cmdline after install; talosctl even warns about it at apply time).
+        extraKernelArgs:
+          - arm64.nobti
+        systemExtensions:
+          officialExtensions:
+            - siderolabs/nonfree-kmod-nvidia-lts
+            - siderolabs/nvidia-container-toolkit-lts
+    networkInterfaces:
+      # Untagged (no vlans: block) — the Spark's switch port isn't confirmed
+      # trunked for VLAN 50 like the other orion nodes. Maintenance-mode DHCP
+      # already proved this range is reachable untagged on this port.
+      # TODO: move to tagged vlanId 50 (+10) once the switch port is verified.
+      - deviceSelector:
+          hardwareAddr: "4c:bb:47:80:5a:0c"
+        dhcp: false
+        mtu: 1500
+        addresses:
+          - 10.50.0.31/24
+        routes:
+          - network: 0.0.0.0/0
+            gateway: 10.50.0.1
+    patches:
+      - "@./patches/nodes/orion-ai-01.yaml"


### PR DESCRIPTION
## Summary
Adds the NVIDIA DGX Spark (GB10 Grace Blackwell, arm64) to `orion` as `orion-ai-01` / `10.50.0.31` — a GPU worker alongside the 5 existing amd64 nodes. Node is live and confirmed stable: GPU kernel modules loaded, joined the cluster, taint/label applied.

## Key findings baked into this config

- **GB10 requires the proprietary NVIDIA driver**, not OSS (`nonfree-kmod-nvidia-lts` + `nvidia-container-toolkit-lts`).
- **`arm64.nobti` must be baked into the Image Factory schematic**, not set via `machine.install.extraKernelArgs` — the latter is a no-op on this hardware's systemd-boot/UKI boot path (Talos even warns about it at apply time: `extra kernel arguments are not supported when booting using SDBoot`). Without it, the NVIDIA arm64 modules panic on load and the node crash-loops. Confirmed via `/proc/cmdline` before/after the fix.
- **Network is untagged** (no `vlans:` block) for now — the Spark's switch port isn't confirmed trunked for VLAN 50 the way the other orion nodes' ports are. A tagged config there made the node fully unreachable (no ARP at all). TODO left in the config to move to tagged VLAN 50 (+10) once the port is verified.
- **The `nvidia.com/gpu` taint is applied via `kubectl taint`, not Talos's `nodeTaints`** — Kubernetes' `NodeRestriction` admission plugin forbids a node modifying its own `.spec.taints` after the Node object already exists, and Talos's own apply controller (`k8s.NodeApplyController`) always runs after that point, so it always gets rejected. Worse, it bundles the label into the same atomic PATCH, so the taint failure was also silently blocking the `nodeLabels` apply until `nodeTaints` was removed from the config entirely.

## Unrelated fix bundled in

`talhelper` was a stale, non-Homebrew-managed binary (3.1.10, several versions behind). It was silently dropping the `vip:` config block during rendering instead of erroring — Talos 1.13 replaced the legacy `vlans[].vip` field with a separate `Layer2VIPConfig` document, and the old talhelper didn't know how to translate it. This meant orion's control-plane VIP (`10.50.0.10`) had **never actually been applied to any control-plane node**, discovered only by chance while debugging DGX Spark connectivity — unrelated to anything in this PR's diff. Fixed locally (`brew install talhelper`) and the corrected config already applied live to all three control planes; the `Brewfile` comment here is just to stop it recurring for future clones.

## Verification

- `task test:build` — 20/20 Kustomizations pass (Flux/Kubernetes layer untouched, as expected).
- `task gen:validate` — yamllint, kubeconform, kube-linter, talhelper schema all clean.
- Live: node `Ready`, `nvidia`/`nvidia_uvm`/`nvidia_drm`/`nvidia_modeset` kernel modules `Live`, `arm64.nobti` confirmed on `/proc/cmdline`, taint + label confirmed on the Node object, VIP reachable and confirmed via `talosctl`/`kubectl` through `10.50.0.10`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added the Orion AI worker node to the cluster.
  - Configured NVIDIA GPU support, GPU-specific scheduling labels, and required system extensions.
  - Added secure networking, certificate settings, and automated full-disk installation.
  - Added compatibility settings for modern kernel and Unified Kernel Image (UKI) environments.

- **Documentation**
  - Documented the need to keep the Talos configuration helper current to prevent newer settings from being omitted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->