### PR TITLE
feat: add Grocy for grocery/pantry inventory tracking

### DIFF
--- a/kubernetes/apps/grocy/README.md
+++ b/kubernetes/apps/grocy/README.md
@@ -1,0 +1,32 @@
+# grocy
+
+Grocery/pantry inventory tracking (barcode scan-in, scan-out on consume,
+min-stock shopping list). LinuxServer.io image — `grocy/grocy-docker` is
+archived; LSIO is the maintained one.
+
+## Configuration
+
+- **Namespace:** `grocy`
+- Container listens on `80`; `patches/` retarget the base's 8080 default
+  (Deployment containerPort, Service targetPort) to match.
+- PVC via the `pvc` component, mounted at `/config` — 2Gi on
+  `rook-ceph-block` (see `postBuild.substitute` in
+  `clusters/orion/grocy.yaml`). SQLite db and config.php live there.
+- `PUID`/`PGID` set to `1000` (LSIO image requirement).
+
+## Ingress / Endpoints
+
+Exposed via the `httproute` component at `${subdomain}.${domain}`
+(`grocy.orion.norseamerican.com`). gethomepage.dev annotations surface it
+under "Inventory".
+
+## First run
+
+Log in as `admin`/`admin`, change the password, generate an API key
+(Settings → Manage API keys) — needed if wiring up the Home Assistant
+`rest:` sensors.
+
+## Troubleshooting
+
+- **Data loss after restart:** Verify the PVC is bound and mounted
+  (`kubectl describe pod -n grocy`).

--- a/kubernetes/apps/grocy/kustomization.yaml
+++ b/kubernetes/apps/grocy/kustomization.yaml
@@ -1,0 +1,50 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ../webapp/base
+  - namespace.yaml
+
+components:
+  - ../webapp/components/httproute      # Gateway API route — the default; orion has no nginx ingress controller
+  - ../webapp/components/pvc            # mounts /data; set storageClass + storageSize in cluster shell postBuild.substitute
+
+namespace: grocy
+namePrefix: grocy-
+
+labels:
+  - includeSelectors: true
+    pairs:
+      app: grocy
+      app.kubernetes.io/name: grocy
+
+images:
+  - name: my-app
+    newName: ghcr.io/linuxserver/grocy
+    newTag: "v4.6.0-ls334"
+
+patches:
+  - target:
+      kind: Deployment
+      name: deploy
+    path: patches/deploy-container-port.yaml
+  - target:
+      kind: Deployment
+      name: deploy
+    path: patches/deploy-config-mountpath.yaml
+  - target:
+      kind: Deployment
+      name: deploy
+    path: patches/deploy-add-env.yaml
+  - target:
+      kind: Deployment
+      name: deploy
+    path: patches/deploy-update-resources.yaml
+  - target:
+      kind: Service
+      name: svc
+    path: patches/svc-target-port.yaml
+  - target:
+      kind: HTTPRoute
+      name: route
+    path: patches/httproute-add-homepage-annotations.yaml

--- a/kubernetes/apps/grocy/namespace.yaml
+++ b/kubernetes/apps/grocy/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: grocy

--- a/kubernetes/apps/grocy/patches/deploy-add-env.yaml
+++ b/kubernetes/apps/grocy/patches/deploy-add-env.yaml
@@ -1,0 +1,9 @@
+- op: add
+  path: /spec/template/spec/containers/0/env
+  value:
+    - name: PUID
+      value: "1000"
+    - name: PGID
+      value: "1000"
+    - name: TZ
+      value: America/Boise

--- a/kubernetes/apps/grocy/patches/deploy-config-mountpath.yaml
+++ b/kubernetes/apps/grocy/patches/deploy-config-mountpath.yaml
@@ -1,0 +1,5 @@
+# pvc component mounts its volume at /data by default; grocy (LSIO image)
+# expects /config.
+- op: replace
+  path: /spec/template/spec/containers/0/volumeMounts/0/mountPath
+  value: /config

--- a/kubernetes/apps/grocy/patches/deploy-container-port.yaml
+++ b/kubernetes/apps/grocy/patches/deploy-container-port.yaml
@@ -1,0 +1,3 @@
+- op: replace
+  path: /spec/template/spec/containers/0/ports/0/containerPort
+  value: 80

--- a/kubernetes/apps/grocy/patches/deploy-update-resources.yaml
+++ b/kubernetes/apps/grocy/patches/deploy-update-resources.yaml
@@ -1,0 +1,12 @@
+# webapp/base's cpu: 10m default throttles anything heavier than a static
+# file server (see #90, #104). Grocy is PHP-FPM + SQLite behind nginx —
+# sized well above that from the start.
+- op: replace
+  path: /spec/template/spec/containers/0/resources
+  value:
+    limits:
+      cpu: 500m
+      memory: 512Mi
+    requests:
+      cpu: 100m
+      memory: 256Mi

--- a/kubernetes/apps/grocy/patches/httproute-add-homepage-annotations.yaml
+++ b/kubernetes/apps/grocy/patches/httproute-add-homepage-annotations.yaml
@@ -1,0 +1,10 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: route
+  annotations:
+    gethomepage.dev/enabled: "true"
+    gethomepage.dev/name: "Grocy"
+    gethomepage.dev/description: "Grocery & pantry inventory tracking"
+    gethomepage.dev/group: "Inventory"
+    gethomepage.dev/icon: "grocy.png"

--- a/kubernetes/apps/grocy/patches/svc-target-port.yaml
+++ b/kubernetes/apps/grocy/patches/svc-target-port.yaml
@@ -1,0 +1,6 @@
+# Service stays on webapp/base's default port 8080 (matches what
+# httproute.yaml's backendRefs.port expects) — but grocy's container
+# actually listens on 80, so targetPort needs to be explicit.
+- op: add
+  path: /spec/ports/0/targetPort
+  value: 80

--- a/kubernetes/clusters/orion/grocy.yaml
+++ b/kubernetes/clusters/orion/grocy.yaml
@@ -1,0 +1,35 @@
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: grocy
+  namespace: flux-system
+spec:
+  interval: 10m
+  retryInterval: 30s
+  timeout: 15m
+  prune: true
+  wait: true
+  dependsOn:
+    - name: cilium
+    - name: gateway
+    - name: cert-manager-issuers
+    - name: cluster-settings
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+  path: ./kubernetes/apps/grocy
+  decryption:
+    provider: sops
+    secretRef:
+      name: sops-age
+  postBuild:
+    substitute:
+      appName: grocy
+      subdomain: grocy
+      storageClass: rook-ceph-block
+      storageSize: 2Gi
+    substituteFrom:
+      - kind: ConfigMap
+        name: cluster-settings
+      - kind: Secret
+        name: cluster-secrets


### PR DESCRIPTION
## What

Deploys [Grocy](https://grocy.info/) — barcode-scan-in on purchase, scan-out
on consume, min-stock-driven shopping list. LinuxServer.io image
(`ghcr.io/linuxserver/grocy:v4.6.0-ls334`); upstream `grocy/grocy-docker` is
archived as of Feb 2026.

Built on `webapp/base` with the `httproute` + `pvc` components — same shape
as `homebox` (container port 80 → base's 8080, `/config` PVC mount, resource
limits sized up from the base's throttling `10m` default per the #90/#104
lesson).

## Scope

This is PR 1 of 2 from the plan (`~/.claude/plans/i-m-looking-for-a-majestic-octopus.md`).
A follow-up PR wires Grocy into Home Assistant as `rest:` sensors. No
forecasting/burn-rate job yet — Grocy only supports static min-stock
thresholds; deferred until there's real scan history to fit against.

## Verification

- `task gen:validate` — clean.
- `task test:build` — 21/21 kustomizations pass, no unresolved `${...}`.
- `task test:kind-up/push/reconcile` — grocy's Kustomization blocks on
  `dependsOn: cilium`, same as every other cilium-dependent app (homebox,
  gateway, pihole, ...) — `CiliumLoadBalancerIPPool` CRD isn't present in
  vanilla kind, a pre-existing harness limitation unrelated to this change.
  Manually unblocked grocy's Kustomization in the disposable kind cluster to
  confirm it applies: pod/PVC came up in the exact same "Pending, no
  rook-ceph-block provisioner in kind" state as homebox does under the same
  unblocking — i.e. grocy behaves identically to the app it's modeled on.
  Torn down after.

## Post-merge (manual, not GitOps-able)

1. Log in at `grocy.orion.norseamerican.com` as `admin`/`admin`, change password.
2. Generate an API key (Settings → Manage API keys) for the follow-up HA PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Grocy deployment and configuration for the Orion cluster.
  * Added persistent storage, web access, resource limits, timezone, and user/group settings.
  * Added Homepage metadata for displaying Grocy in the application dashboard.

* **Documentation**
  * Added setup guidance covering first-run credentials, API key configuration, storage, and restart-related troubleshooting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->