### PR TITLE
fix: nvidia-device-plugin namespace needs privileged Pod Security Standard

### DIFF
--- a/kubernetes/infrastructure/nvidia-device-plugin/namespace.yaml
+++ b/kubernetes/infrastructure/nvidia-device-plugin/namespace.yaml
@@ -1,4 +1,11 @@
+# privileged PSS required — device plugin pods need SYS_ADMIN and hostPath
+# mounts (kubelet-device-plugins-dir, mps-root, mps-shm, cdi-root); baseline
+# (the cluster default) rejects both. Same requirement as cilium's namespace.
 apiVersion: v1
 kind: Namespace
 metadata:
   name: nvidia-device-plugin
+  labels:
+    pod-security.kubernetes.io/enforce: privileged
+    pod-security.kubernetes.io/audit: privileged
+    pod-security.kubernetes.io/warn: privileged


### PR DESCRIPTION
## Root cause

Diagnosed against live orion (read-only). The `nvidia-device-plugin` HelmRelease has been failing on every reconcile attempt since #108 merged — 4 install failures over 13+ hours — which blocked the entire dependency chain: `nvidia-device-plugin` → `vllm` → `hermes-sage`/`hermes-hearth`. No vllm pods were ever created, so this was **not** the unpinned-image or taint-toleration risk flagged in #108 — neither pod got far enough to hit either of those.

Actual cause: the DaemonSet's pods need `SYS_ADMIN` and hostPath mounts (`kubelet-device-plugins-dir`, `mps-root`, `mps-shm`, `cdi-root`), and the `nvidia-device-plugin` namespace never got a Pod Security Standard label, so it fell back to the cluster's `baseline` default — which rejects both:

```
Error creating: pods "nvidia-device-plugin-..." is forbidden: violates
PodSecurity "baseline:latest": non-default capabilities (containers
"nvidia-device-plugin-sidecar", "nvidia-device-plugin-ctr" must not
include "SYS_ADMIN"...), hostPath volumes (...)
```

`cilium`'s namespace has the identical requirement and already carries `pod-security.kubernetes.io/{enforce,audit,warn}: privileged` — I missed applying the same label when scaffolding `nvidia-device-plugin` in #108.

## Fix

Add the same three PSS labels to `kubernetes/infrastructure/nvidia-device-plugin/namespace.yaml`.

## Confirmed NOT the issue (from live cluster)

- Node taint is `nvidia.com/gpu=true:NoSchedule`. The Deployments' toleration (`key: nvidia.com/gpu, operator: Exists`) matches regardless of value — correct as written.
- Image/sm_121 risk is still unvalidated but irrelevant here — vllm pods were never scheduled, so the image was never pulled.

## Verification

`task test:build` (25/25) and `task gen:validate` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added configuration details for the NVIDIA device plugin namespace.

* **Security**
  * Enabled privileged Pod Security Admission enforcement, auditing, and warnings for the namespace.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->