### PR TITLE
fix: vllm Deployments hit K8s' progressDeadlineSeconds default mid-load

### DIFF
--- a/kubernetes/apps/vllm/deployment-aux.yaml
+++ b/kubernetes/apps/vllm/deployment-aux.yaml
@@ -11,6 +11,9 @@ metadata:
 spec:
   revisionHistoryLimit: 3
   replicas: 1
+  # See deployment-main.yaml — same rationale, confirmed live on this
+  # Deployment specifically (hit ProgressDeadlineExceeded at the 600s default).
+  progressDeadlineSeconds: 1800
   strategy:
     type: Recreate
   selector:
@@ -51,7 +54,10 @@ spec:
             - --tool-call-parser=qwen3_coder
             - --enable-prefix-caching
             - --gpu-memory-utilization=0.30
-            - --speculative-config={"method":"qwen3_next_mtp","num_speculative_tokens":3}
+            # "mtp", not the deprecated "qwen3_next_mtp" — vLLM auto-remaps the
+            # old name today (confirmed live) but logs a deprecation warning;
+            # fixed ahead of it being dropped from a future nightly build.
+            - --speculative-config={"method":"mtp","num_speculative_tokens":3}
           ports:
             - name: http
               containerPort: 8000

--- a/kubernetes/apps/vllm/deployment-main.yaml
+++ b/kubernetes/apps/vllm/deployment-main.yaml
@@ -10,6 +10,14 @@ metadata:
 spec:
   revisionHistoryLimit: 3
   replicas: 1
+  # Matches startupProbe's 30-min cold-load budget below. K8s' own default
+  # (600s) is a *separate* watchdog from the probe — it fires independently
+  # and marks the rollout Progressing:False/ProgressDeadlineExceeded, which
+  # Flux's health check reads as Failed, well before a legitimately slow
+  # model load finishes. Confirmed live: both vllm Deployments hit this at
+  # the 600s default while still mid-load, blocking the whole Kustomization
+  # chain despite nothing actually being broken.
+  progressDeadlineSeconds: 1800
   strategy:
     type: Recreate
   selector:


### PR DESCRIPTION
## Root cause

Diagnosed live against orion (read-only), after #110 cleared the way for `nvidia-device-plugin` to come up healthy. Both vllm pods scheduled, pulled the (previously-risky) nightly image successfully, and started loading model weights — but the `vllm` Kustomization still reported unhealthy:

```
health check failed ... failed early due to stalled resources:
[Deployment/vllm/vllm-aux status: 'Failed']
```

`kubectl describe` confirmed both Deployments hit `ProgressDeadlineExceeded`:

```
Progressing False ProgressDeadlineExceeded  "ReplicaSet ... timed out progressing"
```

`progressDeadlineSeconds` defaults to 600s (10 min) and is a **separate watchdog from the `startupProbe`** — it fires on its own schedule and marks the rollout `Failed` the moment 10 minutes pass without a new replica becoming `Available`, regardless of whether the pod is legitimately still starting. Confirmed live: weights were still actively being written to the PVC (23G and growing, mtime seconds old) well past the 10-minute mark — nothing was actually broken, the load was just slower than K8s' default watchdog, which is exactly the scenario the 30-minute `startupProbe` was built for. The Deployment-level deadline just never got raised to match it.

## Fix

- `progressDeadlineSeconds: 1800` on both `vllm-main` and `vllm-aux`, matching the existing `startupProbe` budget.
- Also fixes `vllm-aux`'s `--speculative-config`: `"qwen3_next_mtp"` is deprecated in favor of `"mtp"` — vLLM auto-remaps it today (confirmed via a deprecation warning in live logs) but the alias won't last.

## Verification

`task test:build` (25/25), `task gen:validate` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Extended the model deployment rollout window to 30 minutes, reducing failures caused by slow startup.
  * Updated speculative decoding configuration to use the current method name.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->