### PR TITLE
fix: vllm-aux OOMKilled — rebalance container memory limits

### DIFF
--- a/kubernetes/apps/vllm/deployment-aux.yaml
+++ b/kubernetes/apps/vllm/deployment-aux.yaml
@@ -70,12 +70,22 @@ spec:
             - name: shm
               mountPath: /dev/shm
           resources:
+            # Bumped after a live OOM: this container was genuinely
+            # OOMKilled at the old 40Gi limit while loading (exit 137),
+            # severely enough to trigger the node's kernel OOM killer
+            # (collateral: node_exporter, an unrelated pause process). NVFP4
+            # dequantization plus the MTP speculative-decoding draft model
+            # both add transient memory beyond vllm-main's plainer FP8 load,
+            # so this container gets the larger share — vllm-main's actual
+            # peak (~23GB, see deployment-main.yaml) had far more headroom
+            # than it needed. Combined limits stay ~76% of the node's ~121GiB
+            # (nothing else meaningful is scheduled on orion-ai-01).
             requests:
               cpu: "2"
-              memory: 35Gi
+              memory: 40Gi
             limits:
               cpu: "8"
-              memory: 40Gi
+              memory: 60Gi
               nvidia.com/gpu: 1
           startupProbe:
             httpGet:

--- a/kubernetes/apps/vllm/deployment-main.yaml
+++ b/kubernetes/apps/vllm/deployment-main.yaml
@@ -82,12 +82,18 @@ spec:
           resources:
             # Sized for unified memory: weights + KV cache both draw from this,
             # not a separate host-RAM budget as on a discrete-GPU node.
+            # Rebalanced after a live OOM (see deployment-aux.yaml): this
+            # container's actual measured peak is ~23GB
+            # (cgroup memory.peak, confirmed via `kubectl exec ... cat
+            # /sys/fs/cgroup/memory.peak`) — the original 45Gi limit here was
+            # unused headroom that vllm-aux's heavier NVFP4+MTP load needed
+            # more than this one did.
             requests:
               cpu: "2"
-              memory: 40Gi
+              memory: 25Gi
             limits:
               cpu: "8"
-              memory: 45Gi
+              memory: 32Gi
               nvidia.com/gpu: 1
           # Cold start = weight download (first run) + ~25s JIT compile on every
           # start. Generous startupProbe avoids a restart-loop before first serve.


### PR DESCRIPTION
This is the second fix from the same live-diagnosis session as #111 — got lost when that PR was merged before this commit was pushed, so re-opening cleanly against current main.

## Root cause

Once #111's `progressDeadlineSeconds` fix let both pods actually run long enough to load, `vllm-aux` was genuinely OOMKilled at its 40Gi container limit (exit 137) — severely enough to trigger the node's kernel OOM killer, which also took out unrelated processes (`node_exporter`, a stray `pause` container) as collateral:

```
System OOM encountered, victim process: vllm, pid: 33982
Last State: Terminated / Reason: OOMKilled / Exit Code: 137
```

Checked `vllm-main` (stable, never crashed) for a real baseline via `kubectl exec ... cat /sys/fs/cgroup/memory.peak`: its actual peak was ~23GB against a 45Gi limit — most of that headroom was never used. `vllm-aux`'s load path is inherently heavier (NVFP4 dequantization + the MTP speculative-decoding draft model both add transient memory beyond `vllm-main`'s plain FP8 load), so it needed more of the shared budget than it was given.

## Fix

Rebalanced rather than just inflating both: `vllm-main` 45Gi → 32Gi limit (still ~40% above its observed peak), `vllm-aux` 40Gi → 60Gi limit. Combined limits ~76% of the node's ~121GiB (nothing else meaningful runs on `orion-ai-01` — confirmed via `kubectl describe node`).

## Verification

`task test:build` (25/25), `task gen:validate` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)