### PR TITLE
feat: switch vllm-aux to AEON-7's image + checkpoint, fixing NVFP4 load bug

### DIFF
--- a/kubernetes/apps/vllm/README.md
+++ b/kubernetes/apps/vllm/README.md
@@ -10,10 +10,10 @@ resource sizing, and cold-start probes don't fit that template's defaults
 
 ## Components
 
-| Deployment | Model | Role | Endpoint (in-cluster) |
-|---|---|---|---|
-| `vllm-main` | `Qwen/Qwen3.6-27B-FP8` | Hermes main model | `vllm-main.vllm.svc.cluster.local:8000` |
-| `vllm-aux` | `nvidia/Qwen3.6-35B-A3B-NVFP4` | Hermes auxiliary model | `vllm-aux.vllm.svc.cluster.local:8000` |
+| Deployment | Image | Model | Role | Endpoint (in-cluster) |
+|---|---|---|---|---|
+| `vllm-main` | `vllm/vllm-openai:cu130-nightly` | `Qwen/Qwen3.6-27B-FP8` | Hermes main model | `vllm-main.vllm.svc.cluster.local:8000` |
+| `vllm-aux` | `ghcr.io/aeon-7/aeon-vllm-ultimate:2026-07-27-v0.26.0` | `AEON-7/Qwen3.6-35B-A3B-heretic-NVFP4` | Hermes auxiliary model | `vllm-aux.vllm.svc.cluster.local:8000` |
 
 Both are one `nvidia.com/gpu` request each, sharing the single physical GPU via
 time-slicing (`kubernetes/infrastructure/nvidia-device-plugin/`, 4 replicas
@@ -22,8 +22,8 @@ shared and no RWX/CephFS storage class is needed (`rook-ceph-block`, RWO, is
 enough).
 
 Both the Deployment and Service carry a `model` label (`qwen3.6-27b` /
-`qwen3.6-35b-a3b`) — `kubectl get pods -n vllm -L model` shows what's running
-without digging through container args.
+`qwen3.6-35b-a3b-heretic`) — `kubectl get pods -n vllm -L model` shows what's
+running without digging through container args.
 
 ## Why these two models
 
@@ -35,16 +35,44 @@ Hermes's high-volume, low-difficulty auxiliary calls (title generation, context
 compression, approval scoring, web summarization) where speed matters more than
 the quality edge.
 
+## vllm-aux runs an uncensored checkpoint — read this first
+
+`AEON-7/Qwen3.6-35B-A3B-heretic-NVFP4` is deliberately "abliterated" (safety
+refusals stripped, 5/100 refusal rate per its own model card), not a plain
+re-quantization of stock Qwen3.6-35B-A3B. This was a deliberate, informed
+choice — NVIDIA's official checkpoint hit a real vLLM loader bug on this
+hardware (see below) and this was the fix — but it means the model backing
+Hermes's `approval` role (see `hermes-sage/config.yaml`,
+`hermes-hearth/config.yaml`) currently has no safety guardrails of its own.
+Revisit this if that stops being acceptable — e.g. by routing `approval`
+specifically back to `vllm-main` instead of `vllm-aux`.
+
 ## Known risks — read before deploying
 
-- **Image is unpinned.** `vllm/vllm-openai:cu130-nightly` is a moving tag, not a
-  reproducible pin. Stock vLLM release images lack sm_121 (Blackwell) kernels
-  for aarch64 ([vLLM #36821](https://github.com/vllm-project/vllm/issues/36821),
-  open) — this hardware needs the CUDA 13 nightly track
+- **`vllm-aux` runs an unaudited third-party image.** `ghcr.io/aeon-7/aeon-vllm-ultimate`
+  is a single-maintainer community build carrying unmerged upstream vLLM
+  patches, with an explicit warranty disclaimer. It's pinned to a dated tag
+  (not `:latest`, which the project itself documents as floating) for
+  reproducibility, but the image itself hasn't been security-audited by
+  anyone. Switched to it because NVIDIA's official `nvidia/Qwen3.6-35B-A3B-NVFP4`
+  checkpoint hit a real, currently-open vLLM bug on this hardware — a
+  `KeyError` loading MoE expert scale tensors
+  ([vLLM #44081](https://github.com/vllm-project/vllm/issues/44081),
+  [#38980](https://github.com/vllm-project/vllm/issues/38980), both open, no
+  fix landed). r0b0tlab's `vllm-v0250-cu130-sm121` was the more conservative
+  alternative considered (properly pinned, official checkpoint, but no
+  specific claim of fixing this bug) — revisit that if the AEON-7 image turns
+  out to be unreliable.
+- **`vllm-main`'s image is still unpinned.** `vllm/vllm-openai:cu130-nightly`
+  is a moving tag, not a reproducible pin — whatever's cached on the node from
+  first pull is what actually runs, regardless of what the tag currently
+  points to upstream. Confirmed working for `vllm-main`'s checkpoint
+  specifically; unresolved as a general risk. Stock vLLM release images lack
+  sm_121 (Blackwell) kernels for aarch64
+  ([vLLM #36821](https://github.com/vllm-project/vllm/issues/36821), open) —
+  this hardware needs the CUDA 13 nightly track
   ([vLLM's own DGX Spark writeup](https://vllm.ai/blog/2026-06-01-vllm-dgx-spark)
-  confirms this works). **Resolve a specific digest and pin it before merging**;
-  validate it actually starts on `orion-ai-01` first. If it doesn't, fall back to
-  Ollama for `vllm-aux` and re-scope.
+  confirms this works in general).
 - **Tool-call parser is `qwen3_coder`, not `hermes`.** Wrong parser → tool calls
   arrive as literal text JSON and Hermes fails silently.
 - **`--gpu-memory-utilization` is a fraction of total unified memory**, shared
@@ -52,16 +80,28 @@ the quality edge.
   = 0.70 total, deliberately under the ~0.80 threshold where GB10 has been
   reported to freeze
   ([forum report](https://forums.developer.nvidia.com/t/gemma-4-on-dgx-spark-gb10-system-freeze-at-80-utilization-sm-121-kernel-issues/366060)).
-  Don't raise either without lowering the other to compensate.
-- **Taint toleration is a guess.** The node's taint is applied by hand via
-  `kubectl taint` (not tracked in git — `NodeRestriction` blocks Talos from
-  setting it itself). Confirm the real key/value with
-  `kubectl describe node orion-ai-01` before relying on the tolerations in
-  `deployment-main.yaml` / `deployment-aux.yaml`.
+  Don't raise either without lowering the other to compensate. Separately,
+  confirmed live that container memory *limits* also matter independently of
+  this fraction — `vllm-aux` was genuinely OOMKilled once at its old 40Gi
+  limit (see git history on `deployment-aux.yaml`); current limits (32Gi
+  main / 60Gi aux) are based on `vllm-main`'s measured real peak (~23GB), not
+  just guesswork, but `vllm-aux`'s footprint under the new image/checkpoint
+  is still unconfirmed.
+- **Node taint toleration is confirmed correct.** Live-verified: the taint is
+  `nvidia.com/gpu=true:NoSchedule`, and `operator: Exists` matches regardless
+  of value — no longer an open risk, but still applied by hand via `kubectl
+  taint` and not tracked in git, so it could drift.
 - **Cold start is slow.** First run downloads weights to the PVC (tens of GB)
-  plus ~25s JIT compile on every start. `startupProbe` is generous
-  (up to 30 min) to avoid a restart-loop; if the model is still larger/slower
-  than expected, extend `failureThreshold` further rather than fighting probes.
+  plus JIT compile on every start; this stacks with Kubernetes' own
+  `progressDeadlineSeconds` (separate from the `startupProbe` — both are set
+  to a matching 30-minute budget now, confirmed live that the K8s-level
+  default of 10 minutes fires independently and marks the rollout `Failed`
+  well before a legitimately slow model load finishes).
+- **DFlash speculative decoding is deliberately not configured for `vllm-aux`.**
+  It needs its own unmerged vLLM PR
+  ([#40898](https://github.com/vllm-project/vllm/pull/40898)) on top of
+  everything else already unproven here — get the base serving path working
+  first before adding it back.
 
 ## Verify
 

--- a/kubernetes/apps/vllm/deployment-aux.yaml
+++ b/kubernetes/apps/vllm/deployment-aux.yaml
@@ -1,13 +1,32 @@
 # Hermes "auxiliary" model — title generation, context compression, approval
-# scoring, web summarization. High-volume/low-difficulty, so throughput (NVFP4 +
-# MTP, ~108 tok/s measured) matters more here than the raw quality edge vllm-main has.
+# scoring, web summarization.
+#
+# ⚠ CHECKPOINT NOTICE: AEON-7/Qwen3.6-35B-A3B-heretic-NVFP4 is a deliberately
+# uncensored/"abliterated" variant (safety refusals stripped, 5/100 refusal
+# rate per its own model card) — not a plain re-quantization of the stock
+# model. This was an explicit, informed choice (see PR description), made
+# knowing this same model backs Hermes's `approval` role in
+# hermes-sage/hermes-hearth's config.yaml — i.e. the guardrail-gating role is
+# currently served by a guardrail-stripped model. Revisit if that stops being
+# acceptable.
+#
+# ⚠ IMAGE NOTICE: switched off the official vllm/vllm-openai image because
+# NVIDIA's own nvidia/Qwen3.6-35B-A3B-NVFP4 checkpoint hit a real, currently
+# open vLLM bug on this exact hardware — a KeyError loading MoE expert scale
+# tensors (see vllm-project/vllm#44081, #38980). ghcr.io/aeon-7's image
+# carries unmerged upstream patches specifically for this; it's a
+# single-maintainer, unaudited community build with an explicit warranty
+# disclaimer, pinned to a dated tag (not `:latest`) for reproducibility.
+# Speculative decoding (DFlash) deliberately left out of this first attempt —
+# it needs its own unmerged vLLM PR (#40898) on top of everything else here;
+# get the base path proven first.
 apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: vllm-aux
   labels:
     app.kubernetes.io/name: vllm-aux
-    model: qwen3.6-35b-a3b
+    model: qwen3.6-35b-a3b-heretic
 spec:
   revisionHistoryLimit: 3
   replicas: 1
@@ -23,7 +42,7 @@ spec:
     metadata:
       labels:
         app.kubernetes.io/name: vllm-aux
-        model: qwen3.6-35b-a3b
+        model: qwen3.6-35b-a3b-heretic
     spec:
       serviceAccountName: default
       automountServiceAccountToken: true
@@ -39,13 +58,21 @@ spec:
           effect: NoSchedule
       containers:
         - name: vllm
-          # TODO: same digest-pin caveat as deployment-main.yaml.
-          image: "vllm/vllm-openai:cu130-nightly"
+          # Dated, pinned tag — not `:latest` (which the upstream repo
+          # itself documents as floating, internally pointing at builds like
+          # this one). UNVALIDATED beyond static research: confirm it
+          # actually starts and loads on orion-ai-01 before trusting this.
+          image: "ghcr.io/aeon-7/aeon-vllm-ultimate:2026-07-27-v0.26.0"
           imagePullPolicy: IfNotPresent
+          # This image's default entrypoint is a multi-model fleet launcher;
+          # override to plain `vllm serve` for a single-model container,
+          # matching the image's own documented single-model invocation.
+          command:
+            - vllm
           args:
-            - --model=nvidia/Qwen3.6-35B-A3B-NVFP4
+            - serve
+            - AEON-7/Qwen3.6-35B-A3B-heretic-NVFP4
             - --served-model-name=qwen3.6-35b-a3b
-            - --quantization=modelopt
             - --port=8000
             - --download-dir=/models
             - --max-model-len=65536
@@ -54,10 +81,12 @@ spec:
             - --tool-call-parser=qwen3_coder
             - --enable-prefix-caching
             - --gpu-memory-utilization=0.30
-            # "mtp", not the deprecated "qwen3_next_mtp" — vLLM auto-remaps the
-            # old name today (confirmed live) but logs a deprecation warning;
-            # fixed ahead of it being dropped from a future nightly build.
-            - --speculative-config={"method":"mtp","num_speculative_tokens":3}
+            # compressed-tensors, not modelopt — this checkpoint's actual
+            # quantization format, per the image's own documented recipe.
+            - --quantization=compressed-tensors
+            - --kv-cache-dtype=fp8_e4m3
+            - --attention-backend=TRITON_ATTN
+            - --trust-remote-code
           ports:
             - name: http
               containerPort: 8000
@@ -70,16 +99,11 @@ spec:
             - name: shm
               mountPath: /dev/shm
           resources:
-            # Bumped after a live OOM: this container was genuinely
-            # OOMKilled at the old 40Gi limit while loading (exit 137),
-            # severely enough to trigger the node's kernel OOM killer
-            # (collateral: node_exporter, an unrelated pause process). NVFP4
-            # dequantization plus the MTP speculative-decoding draft model
-            # both add transient memory beyond vllm-main's plainer FP8 load,
-            # so this container gets the larger share — vllm-main's actual
-            # peak (~23GB, see deployment-main.yaml) had far more headroom
-            # than it needed. Combined limits stay ~76% of the node's ~121GiB
-            # (nothing else meaningful is scheduled on orion-ai-01).
+            # See deployment-main.yaml for the OOM history behind these
+            # numbers. Kept as-is for this checkpoint swap — the model is a
+            # similar size (~22GB per its card) to what these limits were
+            # already sized for; revisit if this build's actual footprint
+            # differs once it's running.
             requests:
               cpu: "2"
               memory: 40Gi
@@ -109,6 +133,10 @@ spec:
           persistentVolumeClaim:
             claimName: vllm-aux-weights
         - name: shm
+          # Bumped from 4Gi to 16Gi to match this image's own documented
+          # recipe (--shm-size=16g) — untested whether the smaller size
+          # would've been enough, not worth risking a second failure mode
+          # to find out.
           emptyDir:
             medium: Memory
-            sizeLimit: 4Gi
+            sizeLimit: 16Gi


### PR DESCRIPTION
## Root cause

Live orion: after #112's OOM fix let `vllm-aux` actually reach weight loading, it hit a real, currently-open vLLM bug loading NVIDIA's official checkpoint:

```
KeyError: 'layers.0.mlp.experts.w2_input_scale'
```

Confirmed via research this matches [vLLM #44081](https://github.com/vllm-project/vllm/issues/44081) (same exact checkpoint, `nvidia/Qwen3.6-35B-A3B-NVFP4`, same class of MoE expert scale-tensor mismatch) and [#38980](https://github.com/vllm-project/vllm/issues/38980) (same bug class on this exact hardware, DGX Spark/GB10) — both open, no upstream fix landed. The floating `cu130-nightly` tag we're on isn't reproducible (`imagePullPolicy: IfNotPresent` means whatever got cached at first pull is what runs), and no official vLLM tag was found that's both confirmed to predate this regression and has sm_121 support.

## Fix

Switched `vllm-aux` **only** (`vllm-main` is healthy, untouched) to `ghcr.io/aeon-7/aeon-vllm-ultimate`, a community image carrying unmerged upstream patches for this. Chosen over the more conservative `r0b0tlab/vllm-v0250-cu130-sm121` alternative because it's the only option found that specifically claims to address NVFP4 loading for this model family.

This required more than an image swap — their validated recipe uses their own re-quantized checkpoint (`AEON-7/Qwen3.6-35B-A3B-heretic-NVFP4`, `compressed-tensors` format) rather than NVIDIA's, plus `kv-cache-dtype=fp8_e4m3` and `attention-backend=TRITON_ATTN`. Speculative decoding (DFlash) deliberately left out for now — it needs its own unmerged vLLM PR ([#40898](https://github.com/vllm-project/vllm/pull/40898)) on top of everything else here; prove the base path first.

## ⚠️ Important: uncensored checkpoint

This checkpoint is a deliberately uncensored/"abliterated" model (5/100 refusal rate per its own model card), not just a re-quantization. This was an **explicit, informed choice** — surfaced and confirmed before implementing, not discovered after the fact. It matters because this model backs Hermes's `approval` role in both `hermes-sage` and `hermes-hearth`'s `config.yaml`, meaning the guardrail-gating role is currently served by a guardrail-stripped model. Documented prominently in `vllm/README.md`; revisit if that stops being acceptable (e.g. route `approval` back to `vllm-main` instead).

## Trust note

Both the image (`ghcr.io/aeon-7`) and the checkpoint are single-maintainer, unaudited community sources with an explicit warranty disclaimer. This is a real tradeoff accepted to unblock a genuine upstream bug, not a casual choice — see `vllm/README.md`'s "Known risks" section for the full writeup and the alternative considered.

## Verification

`task test:build` (25/25), `task gen:validate` clean. **Cannot verify the pod actually runs from this environment** — this is unvalidated beyond static research (image existence, documented invocation pattern, checkpoint compatibility claims). Needs a real reconcile on orion to confirm it starts and loads successfully.

🤖 Generated with [Claude Code](https://claude.com/claude-code)