### PR TITLE
fix: vllm-aux PVC too small after checkpoint switch — hard crash confirmed

### DIFF
--- a/kubernetes/apps/vllm/README.md
+++ b/kubernetes/apps/vllm/README.md
@@ -25,6 +25,10 @@ Both the Deployment and Service carry a `model` label (`qwen3.6-27b` /
 `qwen3.6-35b-a3b-heretic`) — `kubectl get pods -n vllm -L model` shows what's
 running without digging through container args.
 
+Both Deployments also run a `clean-stale-models` initContainer that purges any
+cached checkpoint under `/models` not matching the currently-configured model,
+before the main container starts — see "PVCs stay right-sized" below.
+
 ## Why these two models
 
 `Qwen3.6-27B` (dense) leads `Qwen3.6-35B-A3B` (MoE) by 8-11 points on
@@ -46,6 +50,23 @@ Hermes's `approval` role (see `hermes-sage/config.yaml`,
 `hermes-hearth/config.yaml`) currently has no safety guardrails of its own.
 Revisit this if that stops being acceptable — e.g. by routing `approval`
 specifically back to `vllm-main` instead of `vllm-aux`.
+
+## PVCs stay right-sized — checkpoints don't accumulate
+
+Each PVC (`mainStorageSize: 35Gi`, `auxStorageSize: 35Gi` in
+`clusters/orion/vllm.yaml`) is sized for **one** checkpoint plus headroom, not
+for holding old ones alongside new. Learned this live: switching `vllm-aux`
+off NVIDIA's checkpoint onto AEON-7's (see below) left the ~22GB old download
+sitting on the volume with nothing to reclaim it, which filled a 30Gi PVC and
+crashed the pod mid-download with a disk-full error.
+
+Fix is the `clean-stale-models` initContainer on both Deployments — a plain
+`busybox` step that deletes any `models--*` cache directory not matching the
+model the main container is about to serve, every pod start. **Its `KEEP`
+value must be kept in sync with the `--model` (or positional `serve` arg) in
+the same file by hand** — there's no single source of truth linking them, so
+a checkpoint change needs both updated together, or the initContainer will
+delete the checkpoint that's about to be used.
 
 ## Known risks — read before deploying
 

--- a/kubernetes/apps/vllm/deployment-aux.yaml
+++ b/kubernetes/apps/vllm/deployment-aux.yaml
@@ -56,6 +56,39 @@ spec:
         - key: nvidia.com/gpu
           operator: Exists
           effect: NoSchedule
+      # Purges any cached checkpoint that isn't the one currently configured
+      # below, before the main container starts. Learned the hard way (#113
+      # -> disk-full crash): switching --model here without this left the
+      # prior checkpoint's ~22GB sitting on the PVC forever, un-reclaimed.
+      # KEEP must match the model in the main container's args exactly, or
+      # this deletes the checkpoint that's about to be used.
+      initContainers:
+        - name: clean-stale-models
+          image: busybox:1.36.1
+          command:
+            - sh
+            - -c
+            - |
+              set -eu
+              cd /models
+              KEEP="models--AEON-7--Qwen3.6-35B-A3B-heretic-NVFP4"
+              for d in models--*; do
+                [ -d "$d" ] || continue
+                if [ "$d" != "$KEEP" ]; then
+                  echo "Removing stale model cache: $d"
+                  rm -rf -- "$d"
+                fi
+              done
+          volumeMounts:
+            - name: weights
+              mountPath: /models
+          resources:
+            requests:
+              cpu: 50m
+              memory: 32Mi
+            limits:
+              cpu: 200m
+              memory: 64Mi
       containers:
         - name: vllm
           # Dated, pinned tag — not `:latest` (which the upstream repo

--- a/kubernetes/apps/vllm/deployment-main.yaml
+++ b/kubernetes/apps/vllm/deployment-main.yaml
@@ -43,6 +43,40 @@ spec:
         - key: nvidia.com/gpu
           operator: Exists
           effect: NoSchedule
+      # Purges any cached checkpoint that isn't the one currently configured
+      # below, before the main container starts. See deployment-aux.yaml for
+      # why — a real disk-full crash there, caused by a prior checkpoint's
+      # data never getting cleaned up on a model swap. Not hit here yet since
+      # this model hasn't changed, but applied for the same reason up front.
+      # KEEP must match the model in the main container's args exactly, or
+      # this deletes the checkpoint that's about to be used.
+      initContainers:
+        - name: clean-stale-models
+          image: busybox:1.36.1
+          command:
+            - sh
+            - -c
+            - |
+              set -eu
+              cd /models
+              KEEP="models--Qwen--Qwen3.6-27B-FP8"
+              for d in models--*; do
+                [ -d "$d" ] || continue
+                if [ "$d" != "$KEEP" ]; then
+                  echo "Removing stale model cache: $d"
+                  rm -rf -- "$d"
+                fi
+              done
+          volumeMounts:
+            - name: weights
+              mountPath: /models
+          resources:
+            requests:
+              cpu: 50m
+              memory: 32Mi
+            limits:
+              cpu: 200m
+              memory: 64Mi
       containers:
         - name: vllm
           # TODO: pin to a resolved digest, not this moving tag. Stock vLLM release

--- a/kubernetes/clusters/orion/vllm.yaml
+++ b/kubernetes/clusters/orion/vllm.yaml
@@ -27,14 +27,13 @@ spec:
     substitute:
       storageClass: rook-ceph-block
       mainStorageSize: 35Gi
-      # 30Gi wasn't enough once switched off the NVIDIA checkpoint (#113):
-      # the old nvidia/Qwen3.6-35B-A3B-NVFP4 download (~22GB) is still on the
-      # volume with nothing to clean it up automatically, leaving no room for
-      # the new AEON-7/Qwen3.6-35B-A3B-heretic-NVFP4 checkpoint (~23.4GB) —
-      # confirmed live, HF's downloader stalled at 94% disk usage. Sized for
-      # both to coexist rather than requiring manual cleanup; PVC expansion
-      # is non-destructive on rook-ceph-block (allowVolumeExpansion: true).
-      auxStorageSize: 60Gi
+      # Sized for one checkpoint (~23.4GB) plus headroom, matching mainStorageSize
+      # — not sized to hold two checkpoints simultaneously. Both deployments now
+      # run a clean-stale-models initContainer (see deployment-*.yaml) that
+      # purges any cached checkpoint not matching the currently-configured
+      # model before the main container starts, so old data from a prior
+      # checkpoint swap no longer accumulates and doesn't need this padded out.
+      auxStorageSize: 35Gi
     substituteFrom:
       - kind: ConfigMap
         name: cluster-settings

--- a/kubernetes/clusters/orion/vllm.yaml
+++ b/kubernetes/clusters/orion/vllm.yaml
@@ -27,7 +27,14 @@ spec:
     substitute:
       storageClass: rook-ceph-block
       mainStorageSize: 35Gi
-      auxStorageSize: 30Gi
+      # 30Gi wasn't enough once switched off the NVIDIA checkpoint (#113):
+      # the old nvidia/Qwen3.6-35B-A3B-NVFP4 download (~22GB) is still on the
+      # volume with nothing to clean it up automatically, leaving no room for
+      # the new AEON-7/Qwen3.6-35B-A3B-heretic-NVFP4 checkpoint (~23.4GB) —
+      # confirmed live, HF's downloader stalled at 94% disk usage. Sized for
+      # both to coexist rather than requiring manual cleanup; PVC expansion
+      # is non-destructive on rook-ceph-block (allowVolumeExpansion: true).
+      auxStorageSize: 60Gi
     substituteFrom:
       - kind: ConfigMap
         name: cluster-settings


### PR DESCRIPTION
## Root cause

Live orion: after #113 switched `vllm-aux` to the AEON-7 checkpoint, the pod hard-crashed (`RuntimeError: Engine core initialization failed`) shortly after this warning appeared in logs:

```
UserWarning: Not enough free disk space to download the file. The expected
file size is: 23354.24 MB. The target location
/models/models--AEON-7--Qwen3.6-35B-A3B-heretic-NVFP4/blobs only has
8026.32 MB free disk space.
```

Confirmed via `kubectl exec ... df -h /models`: the 30Gi volume was at 94% full.

```
22G   models--nvidia--Qwen3.6-35B-A3B-NVFP4          (stale, from before #113)
5.7G  models--AEON-7--Qwen3.6-35B-A3B-heretic-NVFP4  (new, stuck partway)
```

The old `nvidia/Qwen3.6-35B-A3B-NVFP4` checkpoint never got cleaned up when #113 switched checkpoints — nothing automatically removes stale HF cache directories — leaving no room for the new ~23.4GB checkpoint alongside it.

## Fix (revised)

First commit just grew the PVC to 60Gi to fit both checkpoints side by side. Per feedback, that's the wrong instinct — don't pad the volume to accommodate dead data, delete the dead data and keep it right-sized. Second commit does that properly:

- `auxStorageSize` back down to **35Gi** (matching `mainStorageSize`) — sized for one checkpoint plus headroom, not two.
- Both `vllm-main` and `vllm-aux` gain a **`clean-stale-models` initContainer** (plain `busybox:1.36.1`, tiny pinned image) that deletes any cached `models--*` directory not matching the currently-configured model, before the main container starts. Applied to both Deployments, not just `aux`, so this doesn't recur the next time either model gets swapped.
- The initContainer's `KEEP` value has to be kept in sync by hand with the `--model`/`serve` arg in the same file — there's no single source of truth linking them. Documented prominently in both the initContainer's own comment and `vllm/README.md`'s new "PVCs stay right-sized" section, since getting this wrong deletes the checkpoint that's about to be used.

## Verification

`task test:build` (25/25), `task gen:validate` clean. Manually confirmed the initContainer's multi-line shell script survives `kustomize build` intact on both Deployments.

Optional, unrelated to this PR: the stale `nvidia` checkpoint directory is still on the live PVC from before this merges — it'll get cleaned up automatically the next time `vllm-aux`'s pod restarts, once this is live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)