### PR TITLE
fix: vllm Kustomization timeout shorter than Deployment progressDeadlineSeconds

### DIFF
--- a/kubernetes/clusters/orion/vllm.yaml
+++ b/kubernetes/clusters/orion/vllm.yaml
@@ -6,7 +6,15 @@ metadata:
 spec:
   interval: 10m
   retryInterval: 30s
-  timeout: 15m
+  # Must exceed the Deployments' progressDeadlineSeconds (1800s/30m, see
+  # deployment-*.yaml) — this timeout gates Flux's own wait: true health
+  # check, which is a *separate* budget from the Deployment-level one.
+  # Confirmed live: with this at 15m, Flux reported HealthCheckFailed and
+  # gave up on every reconcile before the Deployment's own 30-min allowance
+  # for a legitimately slow cold load was ever exhausted — the exact
+  # premature-failure problem progressDeadlineSeconds was raised to avoid,
+  # just one layer up. Set with margin above 30m, not equal to it.
+  timeout: 35m
   prune: true
   wait: true
   dependsOn:


### PR DESCRIPTION
## Root cause

Live orion: watching #114 try to reconcile after merge, noticed every attempt was burning a full 15 minutes before failing, and \`Last Attempted Revision\` stayed on #113 far longer than expected — each cycle was retrying from scratch rather than progressing toward #114's actual fix.

\`kubectl describe kustomization vllm\` showed the pattern clearly:

\`\`\`
Warning  HealthCheckFailed  kustomize-controller  health check failed after 15m0.022358556s:
  timeout waiting for: [Deployment/vllm/vllm-aux status: 'InProgress']
\`\`\`

Recurring roughly every 15 minutes. Root cause: this Kustomization's own \`timeout: 15m\` gates Flux's \`wait: true\` health check — a **separate** budget from the Deployments' \`progressDeadlineSeconds: 1800\` (30m, set in #111 specifically so Kubernetes wouldn't prematurely fail a legitimately slow cold model load). At 15m here, Flux gives up and reports \`HealthCheckFailed\` well before that 30-minute allowance is ever exhausted — the exact premature-failure problem #111 fixed at the Deployment level, recurring one layer up at the Kustomization level.

## Fix

\`timeout: 15m\` → \`35m\` — margin above the 30-minute Deployment budget, not equal to it.

## Verification

\`task test:build\` (25/25), \`task gen:validate\` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)