### PR TITLE
fix: vllm-aux OOMKilled again on AEON-7 image, and a related vllm-main crash

### DIFF
--- a/kubernetes/apps/vllm/README.md
+++ b/kubernetes/apps/vllm/README.md
@@ -103,11 +103,25 @@ delete the checkpoint that's about to be used.
   ([forum report](https://forums.developer.nvidia.com/t/gemma-4-on-dgx-spark-gb10-system-freeze-at-80-utilization-sm-121-kernel-issues/366060)).
   Don't raise either without lowering the other to compensate. Separately,
   confirmed live that container memory *limits* also matter independently of
-  this fraction — `vllm-aux` was genuinely OOMKilled once at its old 40Gi
-  limit (see git history on `deployment-aux.yaml`); current limits (32Gi
-  main / 60Gi aux) are based on `vllm-main`'s measured real peak (~23GB), not
-  just guesswork, but `vllm-aux`'s footprint under the new image/checkpoint
-  is still unconfirmed.
+  this fraction — `vllm-aux` has been genuinely OOMKilled twice now (first at
+  40Gi, then again at 60Gi after switching to the AEON-7 image/checkpoint —
+  that attempt got past weight loading and torch.compile cleanly, so it's a
+  sizing gap, not a code bug). Current limits (32Gi main / 80Gi aux) leave
+  ~9.67GiB margin against the node's actual 121.67GiB (confirmed in a crash
+  log, more precise than the ~121GiB estimate used earlier). `vllm-aux`'s
+  real peak still isn't precisely measured — cgroup stats reset on each
+  crash before they could be read — so this may need another round.
+- **Time-slicing gives zero memory isolation between `main` and `aux`.**
+  Confirmed live: when both Deployments restarted around the same time (both
+  got a new pod template from the `clean-stale-models` initContainer added
+  in the same change), `vllm-main` failed to start with
+  `Free memory on device cuda:0 (31.84/121.67 GiB) ... is less than desired
+  GPU memory utilization (0.4, 48.67 GiB)` — `vllm-aux` was mid-load and
+  transiently holding a large chunk of the shared pool at that exact moment.
+  Not a bug in `vllm-main` itself; expected to stop recurring once `vllm-aux`
+  stops crash-looping and the two aren't repeatedly restarting in the same
+  window. No explicit startup ordering/staggering added between them yet —
+  revisit if this keeps happening once `vllm-aux` is otherwise stable.
 - **Node taint toleration is confirmed correct.** Live-verified: the taint is
   `nvidia.com/gpu=true:NoSchedule`, and `operator: Exists` matches regardless
   of value — no longer an open risk, but still applied by hand via `kubectl

--- a/kubernetes/apps/vllm/README.md
+++ b/kubernetes/apps/vllm/README.md
@@ -25,9 +25,11 @@ Both the Deployment and Service carry a `model` label (`qwen3.6-27b` /
 `qwen3.6-35b-a3b-heretic`) — `kubectl get pods -n vllm -L model` shows what's
 running without digging through container args.
 
-Both Deployments also run a `clean-stale-models` initContainer that purges any
-cached checkpoint under `/models` not matching the currently-configured model,
-before the main container starts — see "PVCs stay right-sized" below.
+Both Deployments run a `clean-stale-models` initContainer (purges any cached
+checkpoint that doesn't match what's configured, before the main container
+starts — see "PVCs stay right-sized" below). `vllm-aux` also runs a
+`wait-for-main` initContainer that blocks until `vllm-main` is healthy — see
+"Startup is sequenced" below.
 
 ## Why these two models
 
@@ -55,88 +57,72 @@ specifically back to `vllm-main` instead of `vllm-aux`.
 
 Each PVC (`mainStorageSize: 35Gi`, `auxStorageSize: 35Gi` in
 `clusters/orion/vllm.yaml`) is sized for **one** checkpoint plus headroom, not
-for holding old ones alongside new. Learned this live: switching `vllm-aux`
-off NVIDIA's checkpoint onto AEON-7's (see below) left the ~22GB old download
-sitting on the volume with nothing to reclaim it, which filled a 30Gi PVC and
-crashed the pod mid-download with a disk-full error.
+for holding old ones alongside new. A checkpoint swap once left the old
+download (~22GB) sitting on the volume with nothing to reclaim it, filling a
+30Gi PVC and crashing the pod mid-download with a disk-full error.
 
-Fix is the `clean-stale-models` initContainer on both Deployments — a plain
-`busybox` step that deletes any `models--*` cache directory not matching the
-model the main container is about to serve, every pod start. **Its `KEEP`
-value must be kept in sync with the `--model` (or positional `serve` arg) in
-the same file by hand** — there's no single source of truth linking them, so
-a checkpoint change needs both updated together, or the initContainer will
-delete the checkpoint that's about to be used.
+Fix is the `clean-stale-models` initContainer on both Deployments — deletes
+any `models--*` cache directory not matching the model about to be served,
+every pod start. **Its `KEEP` value must be kept in sync by hand with the
+`--model`/`serve` arg in the same file** — no single source of truth links
+them, so a checkpoint change needs both updated together, or the
+initContainer deletes the checkpoint that's about to be used.
+
+## Startup is sequenced — main first, then aux
+
+`vllm-aux`'s `wait-for-main` initContainer blocks until `vllm-main` reports
+healthy before `vllm-aux` starts loading. Time-slicing gives the two zero
+memory isolation on the shared GPU (see below) — letting both load at once
+once starved `vllm-main` of its GPU memory share mid-startup. Sequencing
+keeps their memory peaks from overlapping. One-directional: if `vllm-main` is
+ever down, `vllm-aux` waits rather than competing with it for memory, which
+is the right failure mode here.
 
 ## Known risks — read before deploying
 
-- **`vllm-aux` runs an unaudited third-party image.** `ghcr.io/aeon-7/aeon-vllm-ultimate`
-  is a single-maintainer community build carrying unmerged upstream vLLM
-  patches, with an explicit warranty disclaimer. It's pinned to a dated tag
-  (not `:latest`, which the project itself documents as floating) for
-  reproducibility, but the image itself hasn't been security-audited by
-  anyone. Switched to it because NVIDIA's official `nvidia/Qwen3.6-35B-A3B-NVFP4`
-  checkpoint hit a real, currently-open vLLM bug on this hardware — a
-  `KeyError` loading MoE expert scale tensors
-  ([vLLM #44081](https://github.com/vllm-project/vllm/issues/44081),
+- **`vllm-aux` runs an unaudited third-party image and checkpoint.**
+  `ghcr.io/aeon-7/aeon-vllm-ultimate` is a single-maintainer community build
+  carrying unmerged upstream vLLM patches, with an explicit warranty
+  disclaimer — pinned to a dated tag (not `:latest`, which the project itself
+  documents as floating) for reproducibility, but not security-audited by
+  anyone. Switched to it because NVIDIA's official
+  `nvidia/Qwen3.6-35B-A3B-NVFP4` checkpoint hits a real, currently-open vLLM
+  bug on this hardware — a `KeyError` loading MoE expert scale tensors
+  ([#44081](https://github.com/vllm-project/vllm/issues/44081),
   [#38980](https://github.com/vllm-project/vllm/issues/38980), both open, no
-  fix landed). r0b0tlab's `vllm-v0250-cu130-sm121` was the more conservative
-  alternative considered (properly pinned, official checkpoint, but no
-  specific claim of fixing this bug) — revisit that if the AEON-7 image turns
-  out to be unreliable.
+  fix landed). `r0b0tlab/vllm-v0250-cu130-sm121` was the more conservative
+  alternative considered (properly pinned, official checkpoint, no specific
+  claim of fixing this bug) — revisit if AEON-7's image proves unreliable.
 - **`vllm-main`'s image is still unpinned.** `vllm/vllm-openai:cu130-nightly`
-  is a moving tag, not a reproducible pin — whatever's cached on the node from
-  first pull is what actually runs, regardless of what the tag currently
-  points to upstream. Confirmed working for `vllm-main`'s checkpoint
-  specifically; unresolved as a general risk. Stock vLLM release images lack
+  is a moving tag — whatever's cached on the node from first pull is what
+  runs, regardless of what the tag points to upstream now. Confirmed working
+  for this checkpoint; unresolved as a general risk. Stock vLLM releases lack
   sm_121 (Blackwell) kernels for aarch64
-  ([vLLM #36821](https://github.com/vllm-project/vllm/issues/36821), open) —
-  this hardware needs the CUDA 13 nightly track
-  ([vLLM's own DGX Spark writeup](https://vllm.ai/blog/2026-06-01-vllm-dgx-spark)
-  confirms this works in general).
-- **Tool-call parser is `qwen3_coder`, not `hermes`.** Wrong parser → tool calls
-  arrive as literal text JSON and Hermes fails silently.
-- **`--gpu-memory-utilization` is a fraction of total unified memory**, shared
-  by both deployments, the OS, and every other pod. `main` (0.40) + `aux` (0.30)
-  = 0.70 total, deliberately under the ~0.80 threshold where GB10 has been
-  reported to freeze
+  ([#36821](https://github.com/vllm-project/vllm/issues/36821), open) — this
+  hardware needs the CUDA 13 nightly track.
+- **Tool-call parser is `qwen3_coder`, not `hermes`.** Wrong parser → tool
+  calls arrive as literal text JSON and Hermes fails silently.
+- **`--gpu-memory-utilization` is a fraction of total unified memory**,
+  shared by both deployments and the OS. `main` (0.40) + `aux` (0.30) = 0.70,
+  under the ~0.80 threshold where GB10 has been reported to freeze
   ([forum report](https://forums.developer.nvidia.com/t/gemma-4-on-dgx-spark-gb10-system-freeze-at-80-utilization-sm-121-kernel-issues/366060)).
-  Don't raise either without lowering the other to compensate. Separately,
-  confirmed live that container memory *limits* also matter independently of
-  this fraction — `vllm-aux` has been genuinely OOMKilled twice now (first at
-  40Gi, then again at 60Gi after switching to the AEON-7 image/checkpoint —
-  that attempt got past weight loading and torch.compile cleanly, so it's a
-  sizing gap, not a code bug). Current limits (32Gi main / 80Gi aux) leave
-  ~9.67GiB margin against the node's actual 121.67GiB (confirmed in a crash
-  log, more precise than the ~121GiB estimate used earlier). `vllm-aux`'s
-  real peak still isn't precisely measured — cgroup stats reset on each
-  crash before they could be read — so this may need another round.
-- **Time-slicing gives zero memory isolation between `main` and `aux`.**
-  Confirmed live: when both Deployments restarted around the same time (both
-  got a new pod template from the `clean-stale-models` initContainer added
-  in the same change), `vllm-main` failed to start with
-  `Free memory on device cuda:0 (31.84/121.67 GiB) ... is less than desired
-  GPU memory utilization (0.4, 48.67 GiB)` — `vllm-aux` was mid-load and
-  transiently holding a large chunk of the shared pool at that exact moment.
-  Not a bug in `vllm-main` itself; expected to stop recurring once `vllm-aux`
-  stops crash-looping and the two aren't repeatedly restarting in the same
-  window. No explicit startup ordering/staggering added between them yet —
-  revisit if this keeps happening once `vllm-aux` is otherwise stable.
-- **Node taint toleration is confirmed correct.** Live-verified: the taint is
+  Container memory *limits* matter independently of this fraction —
+  `vllm-aux` has been OOMKilled twice (40Gi, then 60Gi); current limits
+  (32Gi main / 80Gi aux) leave ~9.67GiB margin against the node's actual
+  121.67GiB. `vllm-aux`'s real peak still isn't precisely measured (cgroup
+  stats reset on crash) — may need another round.
+- **Node taint toleration is confirmed correct.** Live-verified:
   `nvidia.com/gpu=true:NoSchedule`, and `operator: Exists` matches regardless
-  of value — no longer an open risk, but still applied by hand via `kubectl
-  taint` and not tracked in git, so it could drift.
-- **Cold start is slow.** First run downloads weights to the PVC (tens of GB)
-  plus JIT compile on every start; this stacks with Kubernetes' own
-  `progressDeadlineSeconds` (separate from the `startupProbe` — both are set
-  to a matching 30-minute budget now, confirmed live that the K8s-level
-  default of 10 minutes fires independently and marks the rollout `Failed`
-  well before a legitimately slow model load finishes).
-- **DFlash speculative decoding is deliberately not configured for `vllm-aux`.**
-  It needs its own unmerged vLLM PR
+  of value. Still applied by hand via `kubectl taint`, not tracked in git —
+  could drift.
+- **Cold start is slow.** Weight download + JIT compile on every start,
+  stacked with Kubernetes' `progressDeadlineSeconds` and the Flux
+  Kustomization's own `timeout` (both set to a matching ~30-35 min budget —
+  see `clusters/orion/vllm.yaml`).
+- **DFlash speculative decoding isn't configured for `vllm-aux`.** Needs its
+  own unmerged vLLM PR
   ([#40898](https://github.com/vllm-project/vllm/pull/40898)) on top of
-  everything else already unproven here — get the base serving path working
-  first before adding it back.
+  everything else already unproven here.
 
 ## Verify
 

--- a/kubernetes/apps/vllm/deployment-aux.yaml
+++ b/kubernetes/apps/vllm/deployment-aux.yaml
@@ -1,25 +1,17 @@
 # Hermes "auxiliary" model — title generation, context compression, approval
 # scoring, web summarization.
 #
-# ⚠ CHECKPOINT NOTICE: AEON-7/Qwen3.6-35B-A3B-heretic-NVFP4 is a deliberately
-# uncensored/"abliterated" variant (safety refusals stripped, 5/100 refusal
-# rate per its own model card) — not a plain re-quantization of the stock
-# model. This was an explicit, informed choice (see PR description), made
-# knowing this same model backs Hermes's `approval` role in
-# hermes-sage/hermes-hearth's config.yaml — i.e. the guardrail-gating role is
-# currently served by a guardrail-stripped model. Revisit if that stops being
-# acceptable.
+# ⚠ AEON-7/Qwen3.6-35B-A3B-heretic-NVFP4 is a deliberately uncensored
+# ("abliterated", 5/100 refusal rate) checkpoint, not a re-quantization — an
+# informed choice, made knowing it also backs Hermes's `approval` role
+# (hermes-sage/hermes-hearth config.yaml). Revisit if that's unacceptable.
 #
-# ⚠ IMAGE NOTICE: switched off the official vllm/vllm-openai image because
-# NVIDIA's own nvidia/Qwen3.6-35B-A3B-NVFP4 checkpoint hit a real, currently
-# open vLLM bug on this exact hardware — a KeyError loading MoE expert scale
-# tensors (see vllm-project/vllm#44081, #38980). ghcr.io/aeon-7's image
-# carries unmerged upstream patches specifically for this; it's a
-# single-maintainer, unaudited community build with an explicit warranty
-# disclaimer, pinned to a dated tag (not `:latest`) for reproducibility.
-# Speculative decoding (DFlash) deliberately left out of this first attempt —
-# it needs its own unmerged vLLM PR (#40898) on top of everything else here;
-# get the base path proven first.
+# ⚠ Runs ghcr.io/aeon-7's image, not the official vllm-openai one: NVIDIA's
+# own checkpoint hits an open vLLM bug on this hardware (KeyError loading
+# MoE expert scale tensors — vLLM #44081, #38980). AEON-7's image carries
+# unmerged patches for it; single-maintainer, unaudited, warranty-disclaimed
+# (see README.md). DFlash speculative decoding deliberately left out — needs
+# its own unmerged PR (#40898) on top of everything else here.
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -30,8 +22,7 @@ metadata:
 spec:
   revisionHistoryLimit: 3
   replicas: 1
-  # See deployment-main.yaml — same rationale, confirmed live on this
-  # Deployment specifically (hit ProgressDeadlineExceeded at the 600s default).
+  # See deployment-main.yaml.
   progressDeadlineSeconds: 1800
   strategy:
     type: Recreate
@@ -51,18 +42,14 @@ spec:
       runtimeClassName: nvidia
       nodeSelector:
         nvidia.com/gpu.present: "true"
-      # See deployment-main.yaml — same taint caveat applies.
+      # See deployment-main.yaml.
       tolerations:
         - key: nvidia.com/gpu
           operator: Exists
           effect: NoSchedule
-      # Purges any cached checkpoint that isn't the one currently configured
-      # below, before the main container starts. Learned the hard way (#113
-      # -> disk-full crash): switching --model here without this left the
-      # prior checkpoint's ~22GB sitting on the PVC forever, un-reclaimed.
-      # KEEP must match the model in the main container's args exactly, or
-      # this deletes the checkpoint that's about to be used.
       initContainers:
+        # Deletes any cached checkpoint that doesn't match the model below —
+        # see deployment-main.yaml. KEEP must match the model arg exactly.
         - name: clean-stale-models
           image: busybox:1.36.1
           command:
@@ -89,17 +76,36 @@ spec:
             limits:
               cpu: 200m
               memory: 64Mi
+        # Waits for vllm-main to be healthy before this pod loads. Time-
+        # slicing gives no memory isolation between the two — simultaneous
+        # loads once starved vllm-main of its GPU memory share mid-startup
+        # (see README.md). Sequencing keeps their memory peaks from overlapping.
+        - name: wait-for-main
+          image: busybox:1.36.1
+          command:
+            - sh
+            - -c
+            - |
+              set -eu
+              until wget -q -T 5 -O /dev/null http://vllm-main.vllm.svc.cluster.local:8000/health; do
+                echo "Waiting for vllm-main..."
+                sleep 15
+              done
+          resources:
+            requests:
+              cpu: 10m
+              memory: 16Mi
+            limits:
+              cpu: 100m
+              memory: 32Mi
       containers:
         - name: vllm
-          # Dated, pinned tag — not `:latest` (which the upstream repo
-          # itself documents as floating, internally pointing at builds like
-          # this one). UNVALIDATED beyond static research: confirm it
-          # actually starts and loads on orion-ai-01 before trusting this.
+          # Dated, pinned tag — the upstream repo's :latest floats. See
+          # README.md for the trust tradeoff.
           image: "ghcr.io/aeon-7/aeon-vllm-ultimate:2026-07-27-v0.26.0"
           imagePullPolicy: IfNotPresent
-          # This image's default entrypoint is a multi-model fleet launcher;
-          # override to plain `vllm serve` for a single-model container,
-          # matching the image's own documented single-model invocation.
+          # Default entrypoint is a multi-model fleet launcher; override to
+          # plain `vllm serve` for a single model.
           command:
             - vllm
           args:
@@ -114,8 +120,7 @@ spec:
             - --tool-call-parser=qwen3_coder
             - --enable-prefix-caching
             - --gpu-memory-utilization=0.30
-            # compressed-tensors, not modelopt — this checkpoint's actual
-            # quantization format, per the image's own documented recipe.
+            # compressed-tensors — this checkpoint's actual format, not modelopt.
             - --quantization=compressed-tensors
             - --kv-cache-dtype=fp8_e4m3
             - --attention-backend=TRITON_ATTN
@@ -132,18 +137,11 @@ spec:
             - name: shm
               mountPath: /dev/shm
           resources:
-            # Bumped again after a second live OOM on the AEON-7 image: this
-            # attempt got past weight loading (~22GB) and torch.compile
-            # cleanly — no code bug this time — then exceeded the old 60Gi
-            # limit sometime after, likely during CUDA graph capture / KV
-            # cache allocation. Couldn't capture the exact peak (cgroup
-            # stats reset on restart, container was gone before it could be
-            # read) — this bump is evidence-based, not precisely measured;
-            # tighten once a stable real number is observed via
-            # `kubectl exec ... cat /sys/fs/cgroup/memory.peak` on a
-            # successful run. 80Gi + vllm-main's 32Gi leaves ~9.67GiB margin
-            # against the node's actual 121.67GiB (confirmed in the crash
-            # log, not the earlier ~121GiB estimate).
+            # OOMKilled twice at lower limits (40Gi, then 60Gi) — this
+            # image/checkpoint's real footprint is heavier than vllm-main's.
+            # Not precisely measured (cgroup stats reset on crash); may need
+            # another round once a successful run's peak can be read via
+            # `kubectl exec ... cat /sys/fs/cgroup/memory.peak`.
             requests:
               cpu: "2"
               memory: 50Gi
@@ -173,10 +171,7 @@ spec:
           persistentVolumeClaim:
             claimName: vllm-aux-weights
         - name: shm
-          # Bumped from 4Gi to 16Gi to match this image's own documented
-          # recipe (--shm-size=16g) — untested whether the smaller size
-          # would've been enough, not worth risking a second failure mode
-          # to find out.
+          # 16Gi to match this image's documented recipe (--shm-size=16g).
           emptyDir:
             medium: Memory
             sizeLimit: 16Gi

--- a/kubernetes/apps/vllm/deployment-aux.yaml
+++ b/kubernetes/apps/vllm/deployment-aux.yaml
@@ -132,17 +132,24 @@ spec:
             - name: shm
               mountPath: /dev/shm
           resources:
-            # See deployment-main.yaml for the OOM history behind these
-            # numbers. Kept as-is for this checkpoint swap — the model is a
-            # similar size (~22GB per its card) to what these limits were
-            # already sized for; revisit if this build's actual footprint
-            # differs once it's running.
+            # Bumped again after a second live OOM on the AEON-7 image: this
+            # attempt got past weight loading (~22GB) and torch.compile
+            # cleanly — no code bug this time — then exceeded the old 60Gi
+            # limit sometime after, likely during CUDA graph capture / KV
+            # cache allocation. Couldn't capture the exact peak (cgroup
+            # stats reset on restart, container was gone before it could be
+            # read) — this bump is evidence-based, not precisely measured;
+            # tighten once a stable real number is observed via
+            # `kubectl exec ... cat /sys/fs/cgroup/memory.peak` on a
+            # successful run. 80Gi + vllm-main's 32Gi leaves ~9.67GiB margin
+            # against the node's actual 121.67GiB (confirmed in the crash
+            # log, not the earlier ~121GiB estimate).
             requests:
               cpu: "2"
-              memory: 40Gi
+              memory: 50Gi
             limits:
               cpu: "8"
-              memory: 60Gi
+              memory: 80Gi
               nvidia.com/gpu: 1
           startupProbe:
             httpGet:

--- a/kubernetes/apps/vllm/deployment-main.yaml
+++ b/kubernetes/apps/vllm/deployment-main.yaml
@@ -1,5 +1,5 @@
-# Hermes "main" model — drives the agent loop. Qwen3.6-27B leads the MoE aux
-# model by 8-11 pts on Terminal-Bench/agentic benchmarks; see kubernetes/apps/vllm/README.md.
+# Hermes "main" model. Qwen3.6-27B leads the MoE aux model on agentic
+# benchmarks — see kubernetes/apps/vllm/README.md.
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -10,13 +10,9 @@ metadata:
 spec:
   revisionHistoryLimit: 3
   replicas: 1
-  # Matches startupProbe's 30-min cold-load budget below. K8s' own default
-  # (600s) is a *separate* watchdog from the probe — it fires independently
-  # and marks the rollout Progressing:False/ProgressDeadlineExceeded, which
-  # Flux's health check reads as Failed, well before a legitimately slow
-  # model load finishes. Confirmed live: both vllm Deployments hit this at
-  # the 600s default while still mid-load, blocking the whole Kustomization
-  # chain despite nothing actually being broken.
+  # Must stay >= startupProbe's cold-load budget below. K8s' own default
+  # (600s) is a separate watchdog from the probe and fires independently,
+  # marking the rollout Failed before a slow-but-fine load finishes.
   progressDeadlineSeconds: 1800
   strategy:
     type: Recreate
@@ -36,20 +32,16 @@ spec:
       runtimeClassName: nvidia
       nodeSelector:
         nvidia.com/gpu.present: "true"
-      # Toleration must match the taint applied by hand via `kubectl taint` on
-      # orion-ai-01 (not tracked in git — see clusters/orion/patches/nodes/orion-ai-01.yaml).
-      # Confirm the live key/value with `kubectl describe node orion-ai-01` before relying on this.
+      # Must match the taint applied by hand via `kubectl taint` on
+      # orion-ai-01 (not in git — NodeRestriction blocks Talos from setting
+      # it). Verify with `kubectl describe node orion-ai-01` if scheduling fails.
       tolerations:
         - key: nvidia.com/gpu
           operator: Exists
           effect: NoSchedule
-      # Purges any cached checkpoint that isn't the one currently configured
-      # below, before the main container starts. See deployment-aux.yaml for
-      # why — a real disk-full crash there, caused by a prior checkpoint's
-      # data never getting cleaned up on a model swap. Not hit here yet since
-      # this model hasn't changed, but applied for the same reason up front.
-      # KEEP must match the model in the main container's args exactly, or
-      # this deletes the checkpoint that's about to be used.
+      # Deletes any cached checkpoint that doesn't match the model below, so
+      # switching models doesn't leave orphaned data filling the PVC. KEEP
+      # must match the model arg exactly or this deletes what's about to load.
       initContainers:
         - name: clean-stale-models
           image: busybox:1.36.1
@@ -79,10 +71,9 @@ spec:
               memory: 64Mi
       containers:
         - name: vllm
-          # TODO: pin to a resolved digest, not this moving tag. Stock vLLM release
-          # images lack sm_121 (Blackwell) kernels for aarch64 — this hardware needs
-          # the CUDA 13 nightly track. Validate on the real node before merging; see
-          # vLLM issue #36821 and the DGX Spark blog post linked in README.md.
+          # TODO: pin to a resolved digest. Stock vLLM images lack sm_121
+          # (Blackwell) kernels for aarch64 — needs the CUDA 13 nightly
+          # track (vLLM #36821, DGX Spark writeup linked in README.md).
           image: "vllm/vllm-openai:cu130-nightly"
           imagePullPolicy: IfNotPresent
           args:
@@ -93,14 +84,12 @@ spec:
             - --max-model-len=65536
             - --max-num-seqs=8
             - --enable-auto-tool-choice
-            # NOT "hermes" — that parser name refers to the vLLM parser's origin,
-            # not this model family. Qwen3.6 needs its own parser or tool calls
-            # arrive as literal text JSON.
+            # Not "hermes" — that name refers to the parser's origin, not
+            # this model family. Wrong parser = tool calls as literal JSON.
             - --tool-call-parser=qwen3_coder
             - --enable-prefix-caching
-            # Fraction of the *whole* unified-memory pool, shared with vllm-aux,
-            # the OS, and every other pod on the node. Keep main+aux well under 0.75
-            # total — GB10 has reported freezing above ~80% utilization.
+            # Fraction of total unified memory, shared with vllm-aux and the
+            # OS. Keep main+aux combined well under ~0.75.
             - --gpu-memory-utilization=0.40
           ports:
             - name: http
@@ -114,14 +103,9 @@ spec:
             - name: shm
               mountPath: /dev/shm
           resources:
-            # Sized for unified memory: weights + KV cache both draw from this,
-            # not a separate host-RAM budget as on a discrete-GPU node.
-            # Rebalanced after a live OOM (see deployment-aux.yaml): this
-            # container's actual measured peak is ~23GB
-            # (cgroup memory.peak, confirmed via `kubectl exec ... cat
-            # /sys/fs/cgroup/memory.peak`) — the original 45Gi limit here was
-            # unused headroom that vllm-aux's heavier NVFP4+MTP load needed
-            # more than this one did.
+            # Unified memory: weights + KV cache draw from this, not a
+            # separate host-RAM budget. Measured real peak ~23GB (cgroup
+            # memory.peak) — sized with headroom above that.
             requests:
               cpu: "2"
               memory: 25Gi
@@ -129,8 +113,8 @@ spec:
               cpu: "8"
               memory: 32Gi
               nvidia.com/gpu: 1
-          # Cold start = weight download (first run) + ~25s JIT compile on every
-          # start. Generous startupProbe avoids a restart-loop before first serve.
+          # Cold start = weight load + JIT compile. Generous startupProbe
+          # avoids a restart-loop before first serve.
           startupProbe:
             httpGet:
               path: /health

--- a/kubernetes/clusters/orion/vllm.yaml
+++ b/kubernetes/clusters/orion/vllm.yaml
@@ -6,14 +6,9 @@ metadata:
 spec:
   interval: 10m
   retryInterval: 30s
-  # Must exceed the Deployments' progressDeadlineSeconds (1800s/30m, see
-  # deployment-*.yaml) — this timeout gates Flux's own wait: true health
-  # check, which is a *separate* budget from the Deployment-level one.
-  # Confirmed live: with this at 15m, Flux reported HealthCheckFailed and
-  # gave up on every reconcile before the Deployment's own 30-min allowance
-  # for a legitimately slow cold load was ever exhausted — the exact
-  # premature-failure problem progressDeadlineSeconds was raised to avoid,
-  # just one layer up. Set with margin above 30m, not equal to it.
+  # Must exceed the Deployments' progressDeadlineSeconds (30m) — this gates
+  # Flux's own wait: true health check, a separate budget from the
+  # Deployment-level one. Set with margin, not equal.
   timeout: 35m
   prune: true
   wait: true
@@ -35,12 +30,9 @@ spec:
     substitute:
       storageClass: rook-ceph-block
       mainStorageSize: 35Gi
-      # Sized for one checkpoint (~23.4GB) plus headroom, matching mainStorageSize
-      # — not sized to hold two checkpoints simultaneously. Both deployments now
-      # run a clean-stale-models initContainer (see deployment-*.yaml) that
-      # purges any cached checkpoint not matching the currently-configured
-      # model before the main container starts, so old data from a prior
-      # checkpoint swap no longer accumulates and doesn't need this padded out.
+      # One checkpoint plus headroom, not two — the clean-stale-models
+      # initContainer (deployment-*.yaml) purges old checkpoints on every
+      # pod start, so this doesn't need padding for leftover data.
       auxStorageSize: 35Gi
     substituteFrom:
       - kind: ConfigMap


### PR DESCRIPTION
## Root cause

Live orion: after #114+#115 landed, `vllm-aux` actually got through weight loading and `torch.compile` cleanly this time (~22GB weights, ~74s load, ~68s compile) — no disk error, no KeyError, real progress. Then it got OOMKilled anyway a few minutes later, likely during CUDA graph capture / KV cache allocation. The 60Gi limit from #112 was sized against the NVIDIA checkpoint's profile — the AEON-7 image/checkpoint's actual footprint is evidently larger.

Bumped 60Gi → 80Gi. Couldn't capture the exact peak — cgroup `memory.peak` resets per container instance, and the container was gone before it could be read — so this is evidence-based rather than precisely measured. Documented as such; may need another round.

## Also found: vllm-main crash from a GPU-memory race, now fixed

`vllm-main` crashed once in the same window:

```
ValueError: Free memory on device cuda:0 (31.84/121.67 GiB) on startup is
less than desired GPU memory utilization (0.4, 48.67 GiB).
```

Both Deployments got new pod templates from the same prior change (the `clean-stale-models` initContainer), so both restarted close together — `vllm-aux` was transiently holding a large chunk of the shared, non-isolated unified-memory pool right when `vllm-main` tried to claim its own share.

**Fixed**, not just documented: added a `wait-for-main` initContainer to `vllm-aux` that blocks on `vllm-main`'s `/health` (plain busybox `wget` retry loop) before `vllm-aux` starts loading. Sequences their memory peaks instead of relying on them happening not to collide. One-directional — if `vllm-main` is ever down, `vllm-aux` waits rather than competing with it for memory, which is the right failure mode here.

## Also: condensed comments

Comments across all four touched files had accumulated into full incident narratives ("confirmed live at 21:03:18Z...") over several fixes tonight. Cut to the actionable fact + brief why, per the repo's own terse-docs convention — no behavior change, net negative line count despite adding a whole new initContainer.

## Verification

`task test:build` (25/25), `task gen:validate` clean. Confirmed `initContainer` order (`clean-stale-models` → `wait-for-main`) survives `kustomize build` on `vllm-aux`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)