### PR TITLE
fix: vllm-aux gpu-memory-utilization races vllm-main (confirmed: negative KV cache allocation)

### DIFF
--- a/kubernetes/apps/vllm/README.md
+++ b/kubernetes/apps/vllm/README.md
@@ -68,15 +68,17 @@ every pod start. **Its `KEEP` value must be kept in sync by hand with the
 them, so a checkpoint change needs both updated together, or the
 initContainer deletes the checkpoint that's about to be used.
 
-## Startup is sequenced — main first, then aux
+## Startup is sequenced — main first, then aux (partial fix)
 
 `vllm-aux`'s `wait-for-main` initContainer blocks until `vllm-main` reports
-healthy before `vllm-aux` starts loading. Time-slicing gives the two zero
-memory isolation on the shared GPU (see below) — letting both load at once
-once starved `vllm-main` of its GPU memory share mid-startup. Sequencing
-keeps their memory peaks from overlapping. One-directional: if `vllm-main` is
-ever down, `vllm-aux` waits rather than competing with it for memory, which
-is the right failure mode here.
+healthy before `vllm-aux` starts loading. This fixes the *cold-start*
+collision (both loading at once) but isn't sufficient alone — confirmed
+live, `vllm-aux` still crashed on an unrelated retry cycle ~25 minutes later,
+when `vllm-main` finished a late retry and claimed memory at the exact
+moment `vllm-aux` reached its own KV cache allocation check. See the
+`--gpu-memory-utilization` risk below for the actual fix to that. One-
+directional and kept that way: if `vllm-main` is ever down, `vllm-aux` waits
+rather than competing with it for memory.
 
 ## Known risks — read before deploying
 
@@ -102,15 +104,24 @@ is the right failure mode here.
   hardware needs the CUDA 13 nightly track.
 - **Tool-call parser is `qwen3_coder`, not `hermes`.** Wrong parser → tool
   calls arrive as literal text JSON and Hermes fails silently.
-- **`--gpu-memory-utilization` is a fraction of total unified memory**,
-  shared by both deployments and the OS. `main` (0.40) + `aux` (0.30) = 0.70,
-  under the ~0.80 threshold where GB10 has been reported to freeze
-  ([forum report](https://forums.developer.nvidia.com/t/gemma-4-on-dgx-spark-gb10-system-freeze-at-80-utilization-sm-121-kernel-issues/366060)).
+- **`--gpu-memory-utilization` is computed against currently-free memory at
+  the instant each engine initializes, not a fixed reservation.** Confirmed
+  live: `vllm-aux` (0.30) went to `Available KV cache memory: -16.82 GiB` and
+  crashed when `vllm-main` finished a retry and claimed its own share at that
+  exact moment — `wait-for-main` only anchors the start of the race, not its
+  resolution minutes later. `vllm-main`'s real footprint is small (6.76GB
+  resident, 19.66GB peak, confirmed via cgroup `memory.current`/`memory.peak`)
+  and `vllm-aux`'s architecture is inherently cheap on KV cache per token (see
+  "Why these two models"), so `aux` never needed the full 0.30 — lowered to
+  0.15, shrinking its target so it's far less likely to collide with whatever
+  `main` is doing. `main` stays at 0.40 (`main` 0.40 + `aux` 0.15 = 0.55
+  combined target, well under the ~0.80 threshold where GB10 has been
+  reported to freeze —
+  [forum report](https://forums.developer.nvidia.com/t/gemma-4-on-dgx-spark-gb10-system-freeze-at-80-utilization-sm-121-kernel-issues/366060)).
   Container memory *limits* matter independently of this fraction —
-  `vllm-aux` has been OOMKilled twice (40Gi, then 60Gi); current limits
-  (32Gi main / 80Gi aux) leave ~9.67GiB margin against the node's actual
-  121.67GiB. `vllm-aux`'s real peak still isn't precisely measured (cgroup
-  stats reset on crash) — may need another round.
+  `vllm-aux` has been OOMKilled twice on those (40Gi, then 60Gi, unrelated to
+  the utilization-fraction issue); current limits (32Gi main / 80Gi aux)
+  leave ~9.67GiB margin against the node's actual 121.67GiB.
 - **Node taint toleration is confirmed correct.** Live-verified:
   `nvidia.com/gpu=true:NoSchedule`, and `operator: Exists` matches regardless
   of value. Still applied by hand via `kubectl taint`, not tracked in git —

--- a/kubernetes/apps/vllm/deployment-aux.yaml
+++ b/kubernetes/apps/vllm/deployment-aux.yaml
@@ -119,7 +119,18 @@ spec:
             - --enable-auto-tool-choice
             - --tool-call-parser=qwen3_coder
             - --enable-prefix-caching
-            - --gpu-memory-utilization=0.30
+            # Lowered from 0.30: this fraction is computed against whatever's
+            # free at the exact instant this engine initializes, not a fixed
+            # reservation — confirmed live, it went negative
+            # ("Available KV cache memory: -16.82 GiB") when vllm-main
+            # finished retrying and claimed its own share at the same
+            # moment. wait-for-main only anchors the start of that race, not
+            # its resolution minutes later. Real weights here are ~22GB and
+            # this architecture's KV cache is inherently cheap per token (see
+            # README.md), so 0.30 was more target than actually needed —
+            # shrinking it makes the target smaller and far less likely to
+            # collide with whatever vllm-main is doing at that instant.
+            - --gpu-memory-utilization=0.15
             # compressed-tensors — this checkpoint's actual format, not modelopt.
             - --quantization=compressed-tensors
             - --kv-cache-dtype=fp8_e4m3


### PR DESCRIPTION
## Root cause — confirmed, not speculative this time

Live orion: \`vllm-main\` finally succeeded (\`ready=true\`, serving \`200 OK\`) after several retries. ~15 seconds later, \`vllm-aux\` crashed — its first crash all session after settling:

\`\`\`
Available KV cache memory: -16.82 GiB
ValueError: No available memory for the cache blocks.
\`\`\`

**Negative available memory** — this is the definitive mechanism, not a guess. \`vllm-aux\`'s \`--gpu-memory-utilization=0.30\` is computed against whatever's free at the exact instant its engine reaches the KV cache check (after a long, ~22-minute warmup) — not a fixed reservation. \`vllm-main\` finishing a retry and claiming its own share at that precise moment was enough to push \`aux\`'s calculated budget negative.

#116's \`wait-for-main\` initContainer fixes the *cold-start* collision (both loading at once) correctly, but can't fix this — it only gates the start of the race, not its resolution minutes later once both engines are independently retrying/reloading.

## Fix

Checked \`vllm-main\`'s real footprint via \`cgroup memory.current\`/\`memory.peak\` now that it's genuinely serving: **6.76GB resident, 19.66GB peak this run** — far smaller than its 0.40 target ever assumed. \`vllm-aux\`'s architecture is also inherently cheap on KV cache per token (established earlier — only a fraction of its layers carry a KV cache at all). \`0.30\` was more target than \`aux\` actually needed.

Lowered \`vllm-aux\`'s \`--gpu-memory-utilization\` **0.30 → 0.15**, shrinking the window where its target can collide with whatever \`main\` is doing at any given instant. \`vllm-main\` stays at 0.40, untouched — it's stable right now and I don't want to disturb something that's currently working.

## Verification

\`task test:build\` (25/25), \`task gen:validate\` clean. **Not yet confirmed live whether 0.15 fully resolves this** — the failure mode is inherently timing-dependent, so absence of a crash during validation isn't provable from static checks alone. Needs a real reconcile to see if it holds under another simultaneous-retry scenario.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Reduced auxiliary vLLM GPU memory utilization to help prevent out-of-memory failures and memory contention during startup or retries.
  * Clarified that startup sequencing does not prevent collisions during later retries.

* **Documentation**
  * Updated deployment guidance with the recommended memory settings, observed failure history, and available node memory margin.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->