### PR TITLE
extend the utilization trim to vllm-main too (0.40 -> 0.20)

### DIFF
--- a/kubernetes/apps/vllm/README.md
+++ b/kubernetes/apps/vllm/README.md
@@ -109,15 +109,20 @@ rather than competing with it for memory.
   live: `vllm-aux` (0.30) went to `Available KV cache memory: -16.82 GiB` and
   crashed when `vllm-main` finished a retry and claimed its own share at that
   exact moment — `wait-for-main` only anchors the start of the race, not its
-  resolution minutes later. `vllm-main`'s real footprint is small (6.76GB
-  resident, 19.66GB peak, confirmed via cgroup `memory.current`/`memory.peak`)
-  and `vllm-aux`'s architecture is inherently cheap on KV cache per token (see
-  "Why these two models"), so `aux` never needed the full 0.30 — lowered to
-  0.15, shrinking its target so it's far less likely to collide with whatever
-  `main` is doing. `main` stays at 0.40 (`main` 0.40 + `aux` 0.15 = 0.55
-  combined target, well under the ~0.80 threshold where GB10 has been
-  reported to freeze —
-  [forum report](https://forums.developer.nvidia.com/t/gemma-4-on-dgx-spark-gb10-system-freeze-at-80-utilization-sm-121-kernel-issues/366060)).
+  resolution minutes later. Both real footprints are much smaller than their
+  old targets (confirmed via cgroup `memory.current`/`memory.peak`):
+  `vllm-main` at 6.76GB resident / 19.66GB peak against a 48.67GB (0.40)
+  target, and `vllm-aux`'s architecture is inherently cheap on KV cache per
+  token (see "Why these two models"). Both lowered — `aux` 0.30→0.15,
+  `main` 0.40→0.20 — shrinking each target so a collision is far less likely
+  regardless of which one is mid-retry. Combined target dropped 0.70→0.35
+  (~43GB of the node's 121.67GiB, vs. the old ~85GB), well under the ~0.80
+  threshold where GB10 has been reported to freeze —
+  [forum report](https://forums.developer.nvidia.com/t/gemma-4-on-dgx-spark-gb10-system-freeze-at-80-utilization-sm-121-kernel-issues/366060).
+  Still probabilistic, not a guarantee — a smaller static target doesn't
+  prevent a transient spike, only makes one far less likely; if this recurs,
+  the next step is mutual startup coordination between the two Deployments,
+  not further fraction tuning.
   Container memory *limits* matter independently of this fraction —
   `vllm-aux` has been OOMKilled twice on those (40Gi, then 60Gi, unrelated to
   the utilization-fraction issue); current limits (32Gi main / 80Gi aux)

--- a/kubernetes/apps/vllm/deployment-main.yaml
+++ b/kubernetes/apps/vllm/deployment-main.yaml
@@ -88,9 +88,14 @@ spec:
             # this model family. Wrong parser = tool calls as literal JSON.
             - --tool-call-parser=qwen3_coder
             - --enable-prefix-caching
-            # Fraction of total unified memory, shared with vllm-aux and the
-            # OS. Keep main+aux combined well under ~0.75.
-            - --gpu-memory-utilization=0.40
+            # Lowered from 0.40: computed against currently-free memory at
+            # the instant this engine initializes, not a fixed reservation
+            # (same mechanism as vllm-aux — see its comment and README.md).
+            # Real measured peak here was 19.66GB (cgroup memory.peak) — the
+            # old 48.67GB target was mostly unused slack. Shrinking it
+            # reduces how much this claim can collide with whatever
+            # vllm-aux is doing at that same instant.
+            - --gpu-memory-utilization=0.20
           ports:
             - name: http
               containerPort: 8000


### PR DESCRIPTION
Per plan (step 1 of the staged concurrency fix — see conversation): #117 merged with only the `vllm-aux` trim (0.30→0.15); this extends the same fix to `vllm-main`, which was queued as a second commit on that PR but got left behind when it merged mid-push.

## Root cause (same as #117)

Both are still colliding live right now — checked read-only against orion before this PR: both pods unhealthy, node at 95/121Gi used.

## Fix

`vllm-main`'s real footprint is symmetric to what #117 established for `aux`: **6.76GB resident / 19.66GB peak** (cgroup `memory.current`/`memory.peak`) against a 48.67GB (0.40) target — most of that target was unused slack, same pattern as `aux`. Trimmed to **0.20**.

Combined target: 0.70 → 0.35 of the node's 121.67GiB (~85GB → ~43GB), leaving real slack even if both claim their full target at the same instant.

**Still probabilistic, not a guarantee** — documented in `README.md` that if this recurs, the next step is mutual startup coordination between the two Deployments (giving `vllm-main` a symmetric readiness-check initContainer, not just `vllm-aux`), not further fraction tuning.

## Verification

`task test:build` (25/25), `task gen:validate` clean. Not yet validated live through a real concurrent restart — that's the actual test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Configuration**
  * Reduced GPU memory utilization for the main vLLM deployment to lower resource contention and collision risk.
  * Updated operational guidance with measured memory usage and initialization behavior.
* **Documentation**
  * Documented the revised memory targets and clarified that occasional startup failures may still require coordination between services.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->