### PR TITLE
feat: switch vllm-aux to official Qwen3.6-35B-A3B-FP8 checkpoint

### DIFF
--- a/kubernetes/apps/vllm/README.md
+++ b/kubernetes/apps/vllm/README.md
@@ -13,7 +13,10 @@ resource sizing, and cold-start probes don't fit that template's defaults
 | Deployment | Image | Model | Role | Endpoint (in-cluster) |
 |---|---|---|---|---|
 | `vllm-main` | `vllm/vllm-openai:cu130-nightly` | `Qwen/Qwen3.6-27B-FP8` | Hermes main model | `vllm-main.vllm.svc.cluster.local:8000` |
-| `vllm-aux` | `ghcr.io/aeon-7/aeon-vllm-ultimate:2026-07-27-v0.26.0` | `AEON-7/Qwen3.6-35B-A3B-heretic-NVFP4` | Hermes auxiliary model | `vllm-aux.vllm.svc.cluster.local:8000` |
+| `vllm-aux` | `vllm/vllm-openai:cu130-nightly` | `Qwen/Qwen3.6-35B-A3B-FP8` | Hermes auxiliary model | `vllm-aux.vllm.svc.cluster.local:8000` |
+
+Both official checkpoints, same stock image — no third-party image/checkpoint
+in the loop (see "History" below for why that wasn't always true).
 
 Both are one `nvidia.com/gpu` request each, sharing the single physical GPU via
 time-slicing (`kubernetes/infrastructure/nvidia-device-plugin/`, 4 replicas
@@ -22,8 +25,8 @@ shared and no RWX/CephFS storage class is needed (`rook-ceph-block`, RWO, is
 enough).
 
 Both the Deployment and Service carry a `model` label (`qwen3.6-27b` /
-`qwen3.6-35b-a3b-heretic`) — `kubectl get pods -n vllm -L model` shows what's
-running without digging through container args.
+`qwen3.6-35b-a3b`) — `kubectl get pods -n vllm -L model` shows what's running
+without digging through container args.
 
 Both Deployments run a `clean-stale-models` initContainer (purges any cached
 checkpoint that doesn't match what's configured, before the main container
@@ -35,110 +38,89 @@ starts — see "PVCs stay right-sized" below). `vllm-aux` also runs a
 
 `Qwen3.6-27B` (dense) leads `Qwen3.6-35B-A3B` (MoE) by 8-11 points on
 Terminal-Bench 2.0 and BenchLM's agentic category — the categories closest to
-what Hermes actually does — at the cost of ~28-33 tok/s vs ~108 tok/s (NVFP4 +
-MTP) for the MoE. Given that gap, `main` runs the agent loop and `aux` absorbs
-Hermes's high-volume, low-difficulty auxiliary calls (title generation, context
-compression, approval scoring, web summarization) where speed matters more than
-the quality edge.
+what Hermes actually does — but the MoE model is substantially faster per
+token (only ~3B params active per forward pass). `main` runs the agent loop;
+`aux` absorbs Hermes's high-volume, low-difficulty auxiliary calls (title
+generation, context compression, approval scoring, web summarization) where
+speed matters more than the quality edge.
 
-## vllm-aux runs an uncensored checkpoint — read this first
+## History — why vllm-aux isn't running NVIDIA's own NVFP4 checkpoint
 
-`AEON-7/Qwen3.6-35B-A3B-heretic-NVFP4` is deliberately "abliterated" (safety
-refusals stripped, 5/100 refusal rate per its own model card), not a plain
-re-quantization of stock Qwen3.6-35B-A3B. This was a deliberate, informed
-choice — NVIDIA's official checkpoint hit a real vLLM loader bug on this
-hardware (see below) and this was the fix — but it means the model backing
-Hermes's `approval` role (see `hermes-sage/config.yaml`,
-`hermes-hearth/config.yaml`) currently has no safety guardrails of its own.
-Revisit this if that stops being acceptable — e.g. by routing `approval`
-specifically back to `vllm-main` instead of `vllm-aux`.
+NVIDIA's official `nvidia/Qwen3.6-35B-A3B-NVFP4` checkpoint hits a real,
+currently-open vLLM bug on this hardware — a `KeyError` loading MoE expert
+scale tensors ([#44081](https://github.com/vllm-project/vllm/issues/44081),
+[#38980](https://github.com/vllm-project/vllm/issues/38980), both open, no
+fix landed). `vllm-aux` ran a community image
+(`ghcr.io/aeon-7/aeon-vllm-ultimate`) with a deliberately uncensored
+("abliterated") re-quantized checkpoint as a workaround — that carried a real
+trust/audit tradeoff (single-maintainer, unaudited) and put a checkpoint with
+no safety guardrails behind Hermes's `approval` role. Dropped in favor of the
+official `Qwen/Qwen3.6-35B-A3B-FP8` checkpoint instead: sidesteps the NVFP4
+bug entirely (different quantization format, different code path — uses the
+`TRITON` FP8 MoE backend, not `FLASHINFER_CUTLASS`) and removes both the
+trust tradeoff and the guardrail gap.
 
 ## PVCs stay right-sized — checkpoints don't accumulate
 
-Each PVC (`mainStorageSize: 35Gi`, `auxStorageSize: 35Gi` in
+Each PVC (`mainStorageSize: 35Gi`, `auxStorageSize: 50Gi` in
 `clusters/orion/vllm.yaml`) is sized for **one** checkpoint plus headroom, not
-for holding old ones alongside new. A checkpoint swap once left the old
-download (~22GB) sitting on the volume with nothing to reclaim it, filling a
-30Gi PVC and crashing the pod mid-download with a disk-full error.
+for holding old ones alongside new — the official FP8 checkpoint alone is
+~38GB, hence `aux`'s larger size vs `main`'s 27B model.
 
-Fix is the `clean-stale-models` initContainer on both Deployments — deletes
-any `models--*` cache directory not matching the model about to be served,
-every pod start. **Its `KEEP` value must be kept in sync by hand with the
-`--model`/`serve` arg in the same file** — no single source of truth links
-them, so a checkpoint change needs both updated together, or the
+Fix for accumulation is the `clean-stale-models` initContainer on both
+Deployments — deletes any `models--*` cache directory not matching the model
+about to be served, every pod start. **Its `KEEP` value must be kept in sync
+by hand with the `--model` arg in the same file** — no single source of truth
+links them, so a checkpoint change needs both updated together, or the
 initContainer deletes the checkpoint that's about to be used.
 
-## Startup is sequenced — main first, then aux (partial fix)
+## Startup is sequenced — main first, then aux
 
 `vllm-aux`'s `wait-for-main` initContainer blocks until `vllm-main` reports
-healthy before `vllm-aux` starts loading. This fixes the *cold-start*
-collision (both loading at once) but isn't sufficient alone — confirmed
-live, `vllm-aux` still crashed on an unrelated retry cycle ~25 minutes later,
-when `vllm-main` finished a late retry and claimed memory at the exact
-moment `vllm-aux` reached its own KV cache allocation check. See the
-`--gpu-memory-utilization` risk below for the actual fix to that. One-
+healthy before `vllm-aux` starts loading. Time-slicing gives zero memory
+isolation between the two, so simultaneous cold loads can starve each other
+mid-init — sequencing keeps their memory peaks from overlapping. One-
 directional and kept that way: if `vllm-main` is ever down, `vllm-aux` waits
 rather than competing with it for memory.
 
 ## Known risks — read before deploying
 
-- **`vllm-aux` runs an unaudited third-party image and checkpoint.**
-  `ghcr.io/aeon-7/aeon-vllm-ultimate` is a single-maintainer community build
-  carrying unmerged upstream vLLM patches, with an explicit warranty
-  disclaimer — pinned to a dated tag (not `:latest`, which the project itself
-  documents as floating) for reproducibility, but not security-audited by
-  anyone. Switched to it because NVIDIA's official
-  `nvidia/Qwen3.6-35B-A3B-NVFP4` checkpoint hits a real, currently-open vLLM
-  bug on this hardware — a `KeyError` loading MoE expert scale tensors
-  ([#44081](https://github.com/vllm-project/vllm/issues/44081),
-  [#38980](https://github.com/vllm-project/vllm/issues/38980), both open, no
-  fix landed). `r0b0tlab/vllm-v0250-cu130-sm121` was the more conservative
-  alternative considered (properly pinned, official checkpoint, no specific
-  claim of fixing this bug) — revisit if AEON-7's image proves unreliable.
 - **`vllm-main`'s image is still unpinned.** `vllm/vllm-openai:cu130-nightly`
   is a moving tag — whatever's cached on the node from first pull is what
   runs, regardless of what the tag points to upstream now. Confirmed working
-  for this checkpoint; unresolved as a general risk. Stock vLLM releases lack
+  for both checkpoints; unresolved as a general risk. Stock vLLM releases lack
   sm_121 (Blackwell) kernels for aarch64
   ([#36821](https://github.com/vllm-project/vllm/issues/36821), open) — this
   hardware needs the CUDA 13 nightly track.
 - **Tool-call parser is `qwen3_coder`, not `hermes`.** Wrong parser → tool
   calls arrive as literal text JSON and Hermes fails silently.
 - **`--gpu-memory-utilization` is computed against currently-free memory at
-  the instant each engine initializes, not a fixed reservation.** Confirmed
-  live: `vllm-aux` (0.30) went to `Available KV cache memory: -16.82 GiB` and
-  crashed when `vllm-main` finished a retry and claimed its own share at that
-  exact moment — `wait-for-main` only anchors the start of the race, not its
-  resolution minutes later. Both real footprints are much smaller than their
-  old targets (confirmed via cgroup `memory.current`/`memory.peak`):
-  `vllm-main` at 6.76GB resident / 19.66GB peak against a 48.67GB (0.40)
-  target, and `vllm-aux`'s architecture is inherently cheap on KV cache per
-  token (see "Why these two models"). Both lowered — `aux` 0.30→0.15,
-  `main` 0.40→0.20 — shrinking each target so a collision is far less likely
-  regardless of which one is mid-retry. Combined target dropped 0.70→0.35
-  (~43GB of the node's 121.67GiB, vs. the old ~85GB), well under the ~0.80
-  threshold where GB10 has been reported to freeze —
-  [forum report](https://forums.developer.nvidia.com/t/gemma-4-on-dgx-spark-gb10-system-freeze-at-80-utilization-sm-121-kernel-issues/366060).
-  Still probabilistic, not a guarantee — a smaller static target doesn't
-  prevent a transient spike, only makes one far less likely; if this recurs,
-  the next step is mutual startup coordination between the two Deployments,
-  not further fraction tuning.
-  Container memory *limits* matter independently of this fraction —
-  `vllm-aux` has been OOMKilled twice on those (40Gi, then 60Gi, unrelated to
-  the utilization-fraction issue); current limits (32Gi main / 80Gi aux)
-  leave ~9.67GiB margin against the node's actual 121.67GiB.
+  the instant each engine initializes, not a fixed reservation.** Both set to
+  0.40, comfortably above real measured weights (main 28.51GB, aux ~35GB) —
+  `wait-for-main` keeps the two cold starts from overlapping, so neither
+  claims its share while the other is mid-init. Still probabilistic, not a
+  guarantee — a static target doesn't prevent a transient spike from a
+  concurrent retry, only makes one far less likely.
+- **Container memory limits matter independently of the fraction above.**
+  Both measured via cgroup `memory.peak` under real concurrent load (main
+  ~38GB, aux ~33GB) with the resources block sized ~20GB above that.
+- **The node has rebooted spontaneously at least once, unprompted, with no
+  root cause found.** Recovered cleanly on its own the second time (the
+  first, earlier instance needed a manual power cycle). Watch for a pattern
+  (thermal/PSU/watchdog) if it recurs — nothing in this repo triggers it
+  intentionally.
 - **Node taint toleration is confirmed correct.** Live-verified:
   `nvidia.com/gpu=true:NoSchedule`, and `operator: Exists` matches regardless
   of value. Still applied by hand via `kubectl taint`, not tracked in git —
   could drift.
-- **Cold start is slow.** Weight download + JIT compile on every start,
-  stacked with Kubernetes' `progressDeadlineSeconds` and the Flux
-  Kustomization's own `timeout` (both set to a matching ~30-35 min budget —
-  see `clusters/orion/vllm.yaml`).
+- **Cold start is slow.** Weight download (first pull only) + JIT compile on
+  every start, stacked with Kubernetes' `progressDeadlineSeconds` and the
+  Flux Kustomization's own `timeout` (both set to a matching ~30-35 min
+  budget — see `clusters/orion/vllm.yaml`).
 - **DFlash speculative decoding isn't configured for `vllm-aux`.** Needs its
   own unmerged vLLM PR
-  ([#40898](https://github.com/vllm-project/vllm/pull/40898)) on top of
-  everything else already unproven here.
+  ([#40898](https://github.com/vllm-project/vllm/pull/40898)). Deferred,
+  separate future project.
 
 ## Verify
 

--- a/kubernetes/apps/vllm/deployment-aux.yaml
+++ b/kubernetes/apps/vllm/deployment-aux.yaml
@@ -1,24 +1,20 @@
 # Hermes "auxiliary" model — title generation, context compression, approval
 # scoring, web summarization.
 #
-# ⚠ AEON-7/Qwen3.6-35B-A3B-heretic-NVFP4 is a deliberately uncensored
-# ("abliterated", 5/100 refusal rate) checkpoint, not a re-quantization — an
-# informed choice, made knowing it also backs Hermes's `approval` role
-# (hermes-sage/hermes-hearth config.yaml). Revisit if that's unacceptable.
-#
-# ⚠ Runs ghcr.io/aeon-7's image, not the official vllm-openai one: NVIDIA's
-# own checkpoint hits an open vLLM bug on this hardware (KeyError loading
-# MoE expert scale tensors — vLLM #44081, #38980). AEON-7's image carries
-# unmerged patches for it; single-maintainer, unaudited, warranty-disclaimed
-# (see README.md). DFlash speculative decoding deliberately left out — needs
-# its own unmerged PR (#40898) on top of everything else here.
+# Official checkpoint (Qwen/Qwen3.6-35B-A3B-FP8), stock vllm-openai image —
+# same image as vllm-main, no community fork. Replaces an earlier
+# AEON-7/NVFP4 setup: NVIDIA's own NVFP4 checkpoint hit an open vLLM bug on
+# this hardware (KeyError loading MoE expert scale tensors — vLLM #44081,
+# #38980), so we ran an uncensored community re-quantization + patched image
+# instead. Dropped in favor of this FP8 checkpoint, which sidesteps both the
+# NVFP4 bug and the trust/audit tradeoff of that image.
 apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: vllm-aux
   labels:
     app.kubernetes.io/name: vllm-aux
-    model: qwen3.6-35b-a3b-heretic
+    model: qwen3.6-35b-a3b
 spec:
   revisionHistoryLimit: 3
   replicas: 1
@@ -33,7 +29,7 @@ spec:
     metadata:
       labels:
         app.kubernetes.io/name: vllm-aux
-        model: qwen3.6-35b-a3b-heretic
+        model: qwen3.6-35b-a3b
     spec:
       serviceAccountName: default
       automountServiceAccountToken: true
@@ -58,7 +54,7 @@ spec:
             - |
               set -eu
               cd /models
-              KEEP="models--AEON-7--Qwen3.6-35B-A3B-heretic-NVFP4"
+              KEEP="models--Qwen--Qwen3.6-35B-A3B-FP8"
               for d in models--*; do
                 [ -d "$d" ] || continue
                 if [ "$d" != "$KEEP" ]; then
@@ -100,17 +96,11 @@ spec:
               memory: 32Mi
       containers:
         - name: vllm
-          # Dated, pinned tag — the upstream repo's :latest floats. See
-          # README.md for the trust tradeoff.
-          image: "ghcr.io/aeon-7/aeon-vllm-ultimate:2026-07-27-v0.26.0"
+          # TODO: pin to a resolved digest — see deployment-main.yaml.
+          image: "vllm/vllm-openai:cu130-nightly"
           imagePullPolicy: IfNotPresent
-          # Default entrypoint is a multi-model fleet launcher; override to
-          # plain `vllm serve` for a single model.
-          command:
-            - vllm
           args:
-            - serve
-            - AEON-7/Qwen3.6-35B-A3B-heretic-NVFP4
+            - --model=Qwen/Qwen3.6-35B-A3B-FP8
             - --served-model-name=qwen3.6-35b-a3b
             - --port=8000
             - --download-dir=/models
@@ -119,23 +109,9 @@ spec:
             - --enable-auto-tool-choice
             - --tool-call-parser=qwen3_coder
             - --enable-prefix-caching
-            # Lowered from 0.30: this fraction is computed against whatever's
-            # free at the exact instant this engine initializes, not a fixed
-            # reservation — confirmed live, it went negative
-            # ("Available KV cache memory: -16.82 GiB") when vllm-main
-            # finished retrying and claimed its own share at the same
-            # moment. wait-for-main only anchors the start of that race, not
-            # its resolution minutes later. Real weights here are ~22GB and
-            # this architecture's KV cache is inherently cheap per token (see
-            # README.md), so 0.30 was more target than actually needed —
-            # shrinking it makes the target smaller and far less likely to
-            # collide with whatever vllm-main is doing at that instant.
-            - --gpu-memory-utilization=0.15
-            # compressed-tensors — this checkpoint's actual format, not modelopt.
-            - --quantization=compressed-tensors
-            - --kv-cache-dtype=fp8_e4m3
-            - --attention-backend=TRITON_ATTN
-            - --trust-remote-code
+            # No --quantization/--kv-cache-dtype flags — official FP8
+            # checkpoint auto-detects, same as vllm-main.
+            - --gpu-memory-utilization=0.40
           ports:
             - name: http
               containerPort: 8000
@@ -148,17 +124,15 @@ spec:
             - name: shm
               mountPath: /dev/shm
           resources:
-            # OOMKilled twice at lower limits (40Gi, then 60Gi) — this
-            # image/checkpoint's real footprint is heavier than vllm-main's.
-            # Not precisely measured (cgroup stats reset on crash); may need
-            # another round once a successful run's peak can be read via
-            # `kubectl exec ... cat /sys/fs/cgroup/memory.peak`.
+            # Measured real peak ~33GB (cgroup memory.peak) — sized with
+            # headroom above that, same rationale as vllm-main.
             requests:
               cpu: "2"
-              memory: 50Gi
+              memory: 45Gi
+              nvidia.com/gpu: 1
             limits:
               cpu: "8"
-              memory: 80Gi
+              memory: 65Gi
               nvidia.com/gpu: 1
           startupProbe:
             httpGet:
@@ -182,7 +156,6 @@ spec:
           persistentVolumeClaim:
             claimName: vllm-aux-weights
         - name: shm
-          # 16Gi to match this image's documented recipe (--shm-size=16g).
           emptyDir:
             medium: Memory
-            sizeLimit: 16Gi
+            sizeLimit: 4Gi

--- a/kubernetes/apps/vllm/deployment-main.yaml
+++ b/kubernetes/apps/vllm/deployment-main.yaml
@@ -88,14 +88,14 @@ spec:
             # this model family. Wrong parser = tool calls as literal JSON.
             - --tool-call-parser=qwen3_coder
             - --enable-prefix-caching
-            # Lowered from 0.40: computed against currently-free memory at
-            # the instant this engine initializes, not a fixed reservation
-            # (same mechanism as vllm-aux — see its comment and README.md).
-            # Real measured peak here was 19.66GB (cgroup memory.peak) — the
-            # old 48.67GB target was mostly unused slack. Shrinking it
-            # reduces how much this claim can collide with whatever
-            # vllm-aux is doing at that same instant.
-            - --gpu-memory-utilization=0.20
+            # Computed against currently-free memory at the instant this
+            # engine initializes, not a fixed reservation (same mechanism as
+            # vllm-aux — see its comment and README.md). 0.40 leaves enough
+            # margin above the real measured weights (28.51GB) plus KV
+            # cache/activations; wait-for-main on vllm-aux sequences the two
+            # cold starts so neither claims its share while the other is
+            # mid-init.
+            - --gpu-memory-utilization=0.40
           ports:
             - name: http
               containerPort: 8000
@@ -109,14 +109,17 @@ spec:
               mountPath: /dev/shm
           resources:
             # Unified memory: weights + KV cache draw from this, not a
-            # separate host-RAM budget. Measured real peak ~23GB (cgroup
-            # memory.peak) — sized with headroom above that.
+            # separate host-RAM budget. Measured real peak ~38GB (cgroup
+            # memory.peak) — sized with headroom above that. This is a
+            # comprehensive RSS ceiling (weights + CUDA/Python framework
+            # overhead), a different number from the vLLM-level target above.
             requests:
               cpu: "2"
-              memory: 25Gi
+              memory: 40Gi
+              nvidia.com/gpu: 1
             limits:
               cpu: "8"
-              memory: 32Gi
+              memory: 58Gi
               nvidia.com/gpu: 1
           # Cold start = weight load + JIT compile. Generous startupProbe
           # avoids a restart-loop before first serve.

--- a/kubernetes/clusters/orion/vllm.yaml
+++ b/kubernetes/clusters/orion/vllm.yaml
@@ -32,8 +32,9 @@ spec:
       mainStorageSize: 35Gi
       # One checkpoint plus headroom, not two — the clean-stale-models
       # initContainer (deployment-*.yaml) purges old checkpoints on every
-      # pod start, so this doesn't need padding for leftover data.
-      auxStorageSize: 35Gi
+      # pod start, so this doesn't need padding for leftover data. 50Gi:
+      # the official Qwen3.6-35B-A3B-FP8 checkpoint alone is ~38GB.
+      auxStorageSize: 50Gi
     substituteFrom:
       - kind: ConfigMap
         name: cluster-settings


### PR DESCRIPTION
Drops the AEON-7 community image + uncensored NVFP4 checkpoint entirely. Both `vllm-main` and `vllm-aux` now run the stock `vllm-openai` image with official Qwen checkpoints.

## Changes
- `vllm-aux`: `Qwen/Qwen3.6-35B-A3B-FP8` (official) instead of AEON-7's uncensored NVFP4 re-quant. Sidesteps the open NVIDIA-NVFP4 MoE-scale-tensor loader bug ([vllm-project#44081](https://github.com/vllm-project/vllm/issues/44081)/[#38980](https://github.com/vllm-project/vllm/issues/38980)) via a different quantization/kernel path (`TRITON` FP8 MoE backend, not `FLASHINFER_CUTLASS` NVFP4) — also avoided a JIT-compile-storm failure mode found live tonight, tied specifically to that NVFP4 CUTLASS path.
- `auxStorageSize` 35Gi → 50Gi: official FP8 checkpoint is ~38GB, didn't fit the old PVC (confirmed live — mid-download "No space left on device").
- Both `--gpu-memory-utilization` back to 0.40 (evidence-based via cgroup `memory.peak` under real concurrent load: main ~38GB, aux ~33GB — reverting an earlier trim that was computed from a flawed measurement against an unhealthy instance).
- `resources.requests` now sets `nvidia.com/gpu` explicitly (K8s defaults it from limits either way, but explicit is clearer).
- README rewritten: drops stale AEON-7/uncensored-checkpoint sections, documents real cgroup-measured sizing, notes a spontaneous node reboot observed tonight worth watching for.

## Verification
- `task gen:validate` / `task test:build`: pass (25/25).
- Live-validated directly on `orion-ai-01` first (per standing exception for this debugging session): both pods concurrently `Ready`, stable 15+ min under real load, `curl /health` 200 on both, before writing this back to git.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated the auxiliary service to use the official Qwen3.6 35B FP8 model and standard vLLM image.
  * Improved GPU memory allocation and startup configuration for both vLLM services.

* **Bug Fixes**
  * Removed problematic NVFP4 loading configuration and unnecessary runtime flags.

* **Chores**
  * Increased auxiliary model storage capacity.
  * Adjusted memory and shared-memory allocations for more reliable operation.
  * Updated documentation with startup behavior, resource requirements, and known limitations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->