### PR TITLE
fix: hermes-sage image typo (hermes-sagegent -> hermes-agent)

### DIFF
--- a/kubernetes/apps/hermes-sage/kustomization.yaml
+++ b/kubernetes/apps/hermes-sage/kustomization.yaml
@@ -21,7 +21,7 @@ labels:
 
 images:
   - name: my-app
-    newName: nousresearch/hermes-sagegent
+    newName: nousresearch/hermes-agent
     newTag: "latest"
 
 configMapGenerator:


### PR DESCRIPTION
Found while validating tonight's vLLM finalize — \`hermes-sage\` was stuck in \`ImagePullBackOff\` on \`nousresearch/hermes-sagegent:latest\` (nonexistent image). \`hermes-hearth\` correctly uses \`nousresearch/hermes-agent\`; \`hermes-sage\`'s \`kustomization.yaml\` had a typo from scaffolding. One-line fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)