### PR TITLE
feat: enable hermes-sage/hermes-hearth dashboard (incl. terminal)

### DIFF
--- a/kubernetes/apps/hermes-hearth/README.md
+++ b/kubernetes/apps/hermes-hearth/README.md
@@ -9,8 +9,9 @@ the local vLLM models, same as `hermes-sage`.
 ## Configuration
 
 - **Namespace:** `hermes-hearth`
-- Same image, config shape, PVC layout, and `API_SERVER_KEY` secret pattern
-  as `hermes-sage` — see that README for details.
+- Same image, config shape, PVC layout, and `API_SERVER_KEY`/dashboard secret
+  pattern as `hermes-sage` — see that README for details, including the
+  dashboard/terminal security note.
 - Size set in `clusters/orion/hermes-hearth.yaml` `postBuild.substitute`.
 
 ## Ingress / Endpoints

--- a/kubernetes/apps/hermes-hearth/kustomization.yaml
+++ b/kubernetes/apps/hermes-hearth/kustomization.yaml
@@ -37,6 +37,10 @@ patches:
   - target:
       kind: Deployment
       name: deploy
+    path: patches/deploy-dashboard-port.yaml
+  - target:
+      kind: Deployment
+      name: deploy
     path: patches/deploy-args.yaml
   - target:
       kind: Deployment
@@ -59,6 +63,14 @@ patches:
       name: svc
     path: patches/svc-target-port.yaml
   - target:
+      kind: Service
+      name: svc
+    path: patches/svc-dashboard-port.yaml
+  - target:
       kind: HTTPRoute
       name: route
     path: patches/httproute-add-homepage-annotations.yaml
+  - target:
+      kind: HTTPRoute
+      name: route
+    path: patches/httproute-dashboard-port.yaml

--- a/kubernetes/apps/hermes-hearth/patches/deploy-add-env.yaml
+++ b/kubernetes/apps/hermes-hearth/patches/deploy-add-env.yaml
@@ -14,3 +14,24 @@
         secretKeyRef:
           name: hermes-secrets
           key: API_SERVER_KEY
+    # Dashboard (see README.md "Dashboard"). HERMES_DASHBOARD gates the s6
+    # service itself — unset, it exits immediately and the slot reports
+    # down. Non-loopback binds require an auth provider or the dashboard
+    # fails closed; basic auth is the bundled zero-IDP option.
+    - name: HERMES_DASHBOARD
+      value: "1"
+    - name: HERMES_DASHBOARD_BASIC_AUTH_USERNAME
+      valueFrom:
+        secretKeyRef:
+          name: hermes-secrets
+          key: HERMES_DASHBOARD_BASIC_AUTH_USERNAME
+    - name: HERMES_DASHBOARD_BASIC_AUTH_PASSWORD
+      valueFrom:
+        secretKeyRef:
+          name: hermes-secrets
+          key: HERMES_DASHBOARD_BASIC_AUTH_PASSWORD
+    # Cilium Gateway's proxy-header forwarding isn't guaranteed reliable
+    # for this — declare the real external URL so OAuth-style redirect
+    # logic (unused here, but shared code path) doesn't have to guess.
+    - name: HERMES_DASHBOARD_PUBLIC_URL
+      value: "https://hermes-hearth.orion.norseamerican.com"

--- a/kubernetes/apps/hermes-hearth/patches/deploy-dashboard-port.yaml
+++ b/kubernetes/apps/hermes-hearth/patches/deploy-dashboard-port.yaml
@@ -1,0 +1,9 @@
+# Adds the dashboard's port alongside the API port from
+# deploy-container-port.yaml — separate s6 service inside the same
+# container, HERMES_DASHBOARD_PORT default (see deploy-add-env.yaml).
+- op: add
+  path: /spec/template/spec/containers/0/ports/-
+  value:
+    name: dashboard
+    containerPort: 9119
+    protocol: TCP

--- a/kubernetes/apps/hermes-hearth/patches/httproute-dashboard-port.yaml
+++ b/kubernetes/apps/hermes-hearth/patches/httproute-dashboard-port.yaml
@@ -1,0 +1,5 @@
+# Route external traffic to the dashboard port, not the bare API — see
+# README.md "Ingress / Endpoints".
+- op: replace
+  path: /spec/rules/0/backendRefs/0/port
+  value: 9119

--- a/kubernetes/apps/hermes-hearth/patches/svc-dashboard-port.yaml
+++ b/kubernetes/apps/hermes-hearth/patches/svc-dashboard-port.yaml
@@ -1,0 +1,10 @@
+# Second Service port for the dashboard, alongside the API port
+# (svc-target-port.yaml) — httproute-dashboard-port.yaml routes external
+# traffic here instead of the API port.
+- op: add
+  path: /spec/ports/-
+  value:
+    name: dashboard
+    port: 9119
+    protocol: TCP
+    targetPort: 9119

--- a/kubernetes/apps/hermes-hearth/secret.yaml
+++ b/kubernetes/apps/hermes-hearth/secret.yaml
@@ -4,19 +4,21 @@ metadata:
     name: hermes-secrets
 type: Opaque
 stringData:
-    API_SERVER_KEY: ENC[AES256_GCM,data:D6iKMe5s359/Lua3pzYxXDkRGyjrQXliP8koN1S4gqcw8cdbPDdGmZXi3e2m19YOAmGrzsWGiNlzyMJab61pRg==,iv:zLUwqJbRZ1niBx8YfXObrTDJRZRy24fW/KojNiOO5lE=,tag:9Tw0KjNkEagie5qHM27nHg==,type:str]
+    API_SERVER_KEY: ENC[AES256_GCM,data:vrVmftpd1+66Jgo3mlaQNQ4GZHgmNifhrFw7B8vRae1DRiWZ36DdeSMxSqVcu1lmm54703O7ZFeDJp5im+X98Q==,iv:lkjWp2PK5eVs4UAvYvhh3zqH9YdY02Ftcgd7yLAIZfw=,tag:nktm9N+97L4QQd+1Jv6ywg==,type:str]
+    HERMES_DASHBOARD_BASIC_AUTH_USERNAME: ENC[AES256_GCM,data:rCRGU1E=,iv:MWdd/9KCcP6vKXv/iTpE+sjv96NIgtm7KFEGJ3i8MJE=,tag:nkB7xxLg0iYCJgDt+jhMcg==,type:str]
+    HERMES_DASHBOARD_BASIC_AUTH_PASSWORD: ENC[AES256_GCM,data:SlZHtnM43oxY+gamJA7o4obpeEDUlLjz3g/qGphRxCs=,iv:6wFHgAFB1EziVi1ltRxI11A2V+l46d4XliZ5hj6rgGw=,tag:itD2bC/jpE0ge7Gs7xXGJQ==,type:str]
 sops:
     age:
         - enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSB1NUJRYmVlVmFLR0phV2F1
-            Rm1OYmFkRzNGczhnTmo2WlFKaTZFTnA0VENzCk8rY1BPUjFDZmVncGljOWhqUzBG
-            UFgwRWdsREp3TXpnQW5hVkhDYy9FbWMKLS0tIGhVQnNDSjdUQTFuYU51VXF0NlFl
-            clZQeTZwRXBqSXV4VmpIbldoQ0N0SzQKG1W+Vjgp1AQLudU5gc0dWo7z1NP1s49e
-            kOTqTGnB0292ee51+VikCFbuayrX4VMAnpBuF6qTdKFgG8Ws1W+TJg==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBxYTVKUUxvak1JdG5KeDZ3
+            UERhcmtxL3BFMFNqWjJBYmFVSnM2bEJyR1RNCjd6M1d0cVordzA1NWlpc0hSRUNp
+            WDhucFU5dndYU1pkNXl1NWE0cGtkMWcKLS0tIEFvSDJreGRKaC9kSDZOdDFhbjE0
+            bUZIaURPL2ZrKy9jZFI2NVhxR3FUVFEK9+UuXv+b3229tqlmYWQS2J07T5TA1siZ
+            nOZTRMs/EGFyuVa62dT+0uXK3TV7alhF3EIHUwjbN8exCnmyaiZMsA==
             -----END AGE ENCRYPTED FILE-----
           recipient: age13tszh09s5hr9hzjdy8enq7uncz9p2z09hsvky2dn25vudr4cx37s6k5n9z
     encrypted_regex: ^(data|stringData)$
-    lastmodified: "2026-08-09T03:18:36Z"
-    mac: ENC[AES256_GCM,data:PM0Iarit212IBen4WdKZryC6HyZRMAnKusg6vW2iSSGfhfTC2cnWqz4gyfDkTTEpisEAp28IvfkxeRugTx2hVVeFs/nwv++3akg4ynHmEXcq5Z2NpGSisT3bAE4SrOlV4IJrxDLyr3gIOEDHCciq47yIm0b0NKAYrMKjYVgIvDc=,iv:RdjTQXkiqAd8/YyyJj0bm3KwESveZh5F5LhYEQFm5eI=,tag:T2rwSo1CrLtfsP4sZpQuZQ==,type:str]
+    lastmodified: "2026-08-10T13:50:14Z"
+    mac: ENC[AES256_GCM,data:uzhKe69tldNcu2SzVFZBy7r+z+LBM+D6W+mNIRvzOKBfZ3O44g/Qzz8WMb1aXpyHwZVL6C4W6JlqaP1dl22lmEqaiX/z4IwZRZIrHnG4jdIgpoigzwb047ld0aC6UN1z9z1bLzu1vZtMY9Mp8ejLb4gFHSK+IZ23YbltnPnsy4w=,iv:IiM7Fn2Diyprisfw0yWajlAkodeWv2sAH9OclEKuBT8=,tag:zEGI0HVYDuW4rSV9A88FaA==,type:str]
     version: 3.13.3

--- a/kubernetes/apps/hermes-sage/README.md
+++ b/kubernetes/apps/hermes-sage/README.md
@@ -24,13 +24,37 @@ keys, `model.provider: custom` in `config/config.yaml` routes to
   `API_SERVER_ENABLED=true`.
 - `PUID`/`PGID` set to `1000`.
 
+## Dashboard
+
+`hermes-agent` runs the dashboard as a separate s6 service on its own port
+(`9119`, distinct from the API's `8642`) — gated behind `HERMES_DASHBOARD`,
+which does nothing unless set (the service exits immediately and stays
+"supervised, permanent failure" otherwise). Enabled here via
+`deploy-add-env.yaml`. Includes the embedded xterm.js terminal, running
+against `terminal.backend: local` (the framework default — commands execute
+directly in this pod's own container, not a further-sandboxed nested
+container; the pod boundary is the only isolation). Revisit if that's not
+acceptable — `terminal.backend: docker` needs Docker-in-Docker or a sidecar
+daemon, real added complexity not set up here.
+
+A non-loopback dashboard bind (`0.0.0.0`, required to reach it through the
+Service) fails closed without a registered auth provider. Wired up here with
+the bundled zero-IDP basic-auth plugin — `HERMES_DASHBOARD_BASIC_AUTH_USERNAME`/
+`_PASSWORD` in `secret.yaml` (SOPS-encrypted, plaintext accepted — hashed
+in-memory at load, not stored hashed at rest).
+
+`httproute-dashboard-port.yaml` points external traffic at the dashboard port
+(`9119`) instead of the bare API (`8642`) — the API remains reachable
+in-cluster via the Service's `http` port if anything ever needs it, just not
+externally routed.
+
 ## Ingress / Endpoints
 
 Exposed via the `httproute` component at `${subdomain}.${domain}`
 (`hermes-sage.orion.norseamerican.com`) — optional, only useful for reaching
-the dashboard/API from outside the cluster. gethomepage.dev annotations
-surface it under "AI". Nothing in this stack requires external access:
-Hermes talks to vLLM over in-cluster DNS.
+the dashboard from outside the cluster. gethomepage.dev annotations surface
+it under "AI". Nothing in this stack requires external access: Hermes talks
+to vLLM over in-cluster DNS.
 
 ## Troubleshooting
 

--- a/kubernetes/apps/hermes-sage/kustomization.yaml
+++ b/kubernetes/apps/hermes-sage/kustomization.yaml
@@ -37,6 +37,10 @@ patches:
   - target:
       kind: Deployment
       name: deploy
+    path: patches/deploy-dashboard-port.yaml
+  - target:
+      kind: Deployment
+      name: deploy
     path: patches/deploy-args.yaml
   - target:
       kind: Deployment
@@ -59,6 +63,14 @@ patches:
       name: svc
     path: patches/svc-target-port.yaml
   - target:
+      kind: Service
+      name: svc
+    path: patches/svc-dashboard-port.yaml
+  - target:
       kind: HTTPRoute
       name: route
     path: patches/httproute-add-homepage-annotations.yaml
+  - target:
+      kind: HTTPRoute
+      name: route
+    path: patches/httproute-dashboard-port.yaml

--- a/kubernetes/apps/hermes-sage/patches/deploy-add-env.yaml
+++ b/kubernetes/apps/hermes-sage/patches/deploy-add-env.yaml
@@ -14,3 +14,24 @@
         secretKeyRef:
           name: hermes-secrets
           key: API_SERVER_KEY
+    # Dashboard (see README.md "Dashboard"). HERMES_DASHBOARD gates the s6
+    # service itself — unset, it exits immediately and the slot reports
+    # down. Non-loopback binds require an auth provider or the dashboard
+    # fails closed; basic auth is the bundled zero-IDP option.
+    - name: HERMES_DASHBOARD
+      value: "1"
+    - name: HERMES_DASHBOARD_BASIC_AUTH_USERNAME
+      valueFrom:
+        secretKeyRef:
+          name: hermes-secrets
+          key: HERMES_DASHBOARD_BASIC_AUTH_USERNAME
+    - name: HERMES_DASHBOARD_BASIC_AUTH_PASSWORD
+      valueFrom:
+        secretKeyRef:
+          name: hermes-secrets
+          key: HERMES_DASHBOARD_BASIC_AUTH_PASSWORD
+    # Cilium Gateway's proxy-header forwarding isn't guaranteed reliable
+    # for this — declare the real external URL so OAuth-style redirect
+    # logic (unused here, but shared code path) doesn't have to guess.
+    - name: HERMES_DASHBOARD_PUBLIC_URL
+      value: "https://hermes-sage.orion.norseamerican.com"

--- a/kubernetes/apps/hermes-sage/patches/deploy-dashboard-port.yaml
+++ b/kubernetes/apps/hermes-sage/patches/deploy-dashboard-port.yaml
@@ -1,0 +1,9 @@
+# Adds the dashboard's port alongside the API port from
+# deploy-container-port.yaml — separate s6 service inside the same
+# container, HERMES_DASHBOARD_PORT default (see deploy-add-env.yaml).
+- op: add
+  path: /spec/template/spec/containers/0/ports/-
+  value:
+    name: dashboard
+    containerPort: 9119
+    protocol: TCP

--- a/kubernetes/apps/hermes-sage/patches/httproute-dashboard-port.yaml
+++ b/kubernetes/apps/hermes-sage/patches/httproute-dashboard-port.yaml
@@ -1,0 +1,5 @@
+# Route external traffic to the dashboard port, not the bare API — see
+# README.md "Ingress / Endpoints".
+- op: replace
+  path: /spec/rules/0/backendRefs/0/port
+  value: 9119

--- a/kubernetes/apps/hermes-sage/patches/svc-dashboard-port.yaml
+++ b/kubernetes/apps/hermes-sage/patches/svc-dashboard-port.yaml
@@ -1,0 +1,10 @@
+# Second Service port for the dashboard, alongside the API port
+# (svc-target-port.yaml) — httproute-dashboard-port.yaml routes external
+# traffic here instead of the API port.
+- op: add
+  path: /spec/ports/-
+  value:
+    name: dashboard
+    port: 9119
+    protocol: TCP
+    targetPort: 9119

--- a/kubernetes/apps/hermes-sage/secret.yaml
+++ b/kubernetes/apps/hermes-sage/secret.yaml
@@ -4,19 +4,21 @@ metadata:
     name: hermes-secrets
 type: Opaque
 stringData:
-    API_SERVER_KEY: ENC[AES256_GCM,data:XjDayaNnrH/dGytAad7DgZWzI2KbeJMw7KM+DgKGYrBQlazJh9430g53Jd/qQvZSXgec3E77BZLPOan+iB4fbQ==,iv:++EbrXihFxU4GzSigatVHkTgno4j9kSXodS+m8h3PyM=,tag:RKfmfNdXzZaaOhqK123i3A==,type:str]
+    API_SERVER_KEY: ENC[AES256_GCM,data:GSKOu69KcNksLTIbq9kuV91zpEWDHKQre1+Jd1EQPy6xLx3HaKGgcffmdXRmu2BQVBDkdD7yUxqa1pcW0o5KiQ==,iv:Hj5Su/OkflEaCCIQtwFFmjzjLaXTy7g2EA/WDTMJNO4=,tag:vpXI/joTNBPtsXaR+R+ZQA==,type:str]
+    HERMES_DASHBOARD_BASIC_AUTH_USERNAME: ENC[AES256_GCM,data:U06owUY=,iv:rjTV9cREuPQpiFL1wtnOn5wi5rXWer4BgevCjBK3oOQ=,tag:mPy4IWKS8fU18yiE97HlMg==,type:str]
+    HERMES_DASHBOARD_BASIC_AUTH_PASSWORD: ENC[AES256_GCM,data:CpEBYrEAqgbpYMrpQAYCycvc+LfHGqUogaJAvKWxdqo=,iv:k3+AKZGVbS7ms/kPAnCJQ/jR6+y1e5C6LMxz5RbRhIw=,tag:MCVETkpEP6UE9zwkcsSJcw==,type:str]
 sops:
     age:
         - enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSA4T0ZiMXpNOTZGWWYrZEVU
-            bWhyblVzdEp6cU5FdWJhTmhtNTNQQXNhbGhJCkZKOHgxV2F3d3FLcGVobEFrUlhZ
-            dXF4QW9wSHpsaVZYdEVrNUZpN3d6Rk0KLS0tIHZPV1pzbEdXM2p3Q2xkUDF1SkxM
-            ditHaXIvSUJMTkNMVTNjR1ZWWW5EaDAKRTcuTg9FykDvs9acLbkvVk9kkSklEs2T
-            paMPzq1MuBGmooQqSUdjf6fQAOhKhzHLY2c7qT8XBEWYkkyo4Qhxog==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBNeVdEYy9VeElvOWFIL3dE
+            ZVI1ZGpkMmw0ZE9TTHNUVGRDQkVjbVRuaDBJCnozei9RYkU5K2ZPZitJZ0RiNU00
+            Q1dlNWtuMmdNWW5MVHVsOUpZMSs1bHcKLS0tIDhiTGQ1VFJDOG54Znd2Sm8zNjZz
+            MGo4WDhCMmN0NXUxQWlNSER2RENwQzQK5Rz3ZQiPdwWjISTUE+cRm0ffdqAWVR+O
+            lkuzZonrK7sH6I+OhCEQWkhCM8UB6R7ccYvEKy/UX0gmh/SEloBOow==
             -----END AGE ENCRYPTED FILE-----
           recipient: age13tszh09s5hr9hzjdy8enq7uncz9p2z09hsvky2dn25vudr4cx37s6k5n9z
     encrypted_regex: ^(data|stringData)$
-    lastmodified: "2026-08-09T03:18:36Z"
-    mac: ENC[AES256_GCM,data:yooXVLvAWhL45hTCxBmoZLAYrgT4AuCwxi85iJR8WDUrT040y+5ByIcKLgmSxBY9je66SrOyqAui+nzN1FjvGE8Kt2+Ms+x9jTdzR1N7sCbC7CVf4eWnAy8lY8XX8GQyeAaBc0jdS1FjcBOvtrT1qxXTs5EORc6v1oYmGZoxt+c=,iv:KtM7R+5Fl1s0HrcEUsXp6cE7OtC+AaIevWfQdHXV8EE=,tag:XH+RsHfkAB9f0WBPbpuM5g==,type:str]
+    lastmodified: "2026-08-10T13:49:01Z"
+    mac: ENC[AES256_GCM,data:BgXWDE8btgwlmPDFxwSwIEmg7lJaRGDpgs5M9sBzVVT2kXU1hlAfeHZbQWROiIz7V6jo5X18/hq+bh3qMz//S38kaFhZKnlZr1NM5S9btlpnjw88zl8twrqyzVxY2OpUHkNGbWBs0ijuMw3NqSi+8Bo13Yq6II6XjLCS4upLdh4=,iv:Gm/W/Ckxuc1ggnzQ6pbgWFFZkAI/jUxdicyeQbcwc5o=,tag:+8VgjIYKPyNP5omATrENTQ==,type:str]
     version: 3.13.3


### PR DESCRIPTION
Fixes the 404 you hit — root cause: the dashboard is a separate s6 service on its own port (9119) inside the `hermes-agent` image, gated behind `HERMES_DASHBOARD` (unset by default). The httproute was routing to the bare API port (8642), which has no root page — that's the 404. `/health` on that port was returning 200 the whole time, so nothing was actually broken, just not what you were trying to reach.

## Changes
- `HERMES_DASHBOARD=1` + basic-auth env vars (new `secret.yaml` keys — non-loopback dashboard binds fail closed without a registered auth provider).
- `HERMES_DASHBOARD_PUBLIC_URL` set explicitly (Cilium Gateway's proxy-header forwarding isn't guaranteed for the shared OAuth-redirect code path, even though OAuth itself is unused here).
- New container/Service port (9119) for the dashboard; `httproute-dashboard-port.yaml` repoints external traffic there instead of the bare API. API stays reachable in-cluster on the existing Service port if anything needs it.
- **Terminal**: the dashboard includes an embedded xterm.js terminal by default, running against `terminal.backend: local` — commands execute directly in the pod's own container (no further sandboxing beyond the pod boundary). Documented as a known tradeoff in `hermes-sage/README.md` rather than silently changed. Flag if you'd rather have `terminal.backend: docker` (needs DinD/sidecar — real added complexity, not set up here).

## Login
Username `admin`, password is per-app and lives in each `secret.yaml` (SOPS-encrypted, plaintext at rest but hashed in-memory by the bundled basic-auth plugin before use).

## Verification
`task gen:validate` / `task test:build`: pass (25/25). Not live-tested directly (plain `kubectl apply -k` can't resolve Flux's `${subdomain}`/`${storageSize}`-style substitution vars — that's what `test:build` exercises instead); will confirm after merge once Flux reconciles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added externally accessible Hermes dashboards for both deployments on port 9119.
  - Enabled dashboard access with basic authentication and secure credential configuration.
  - Configured HTTPS routing to send external dashboard traffic to the new dashboard endpoint while keeping the API available internally.

- **Documentation**
  - Updated setup and security guidance, including dashboard access, terminal connectivity, authentication, and routing behavior.

- **Security**
  - Added and refreshed encrypted dashboard credentials and API authentication secrets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->