### PR TITLE
feat: expose vllm-aux as a selectable model in hermes dashboards

### DIFF
--- a/kubernetes/apps/hermes-hearth/config/config.yaml
+++ b/kubernetes/apps/hermes-hearth/config/config.yaml
@@ -8,6 +8,17 @@ model:
   default: qwen3.6-27b
   context_length: 64000
 
+# Registers vllm-aux as a second user-selectable model (dashboard model
+# picker / `/model` in chat) — distinct from auxiliary_models below, which
+# only routes specific internal tasks to it and doesn't make it selectable
+# on its own.
+providers:
+  vllm-aux:
+    base_url: http://vllm-aux.vllm.svc.cluster.local:8000/v1
+    models:
+      - qwen3.6-35b-a3b
+    context_length: 65536
+
 auxiliary_models:
   title:
     provider: custom

--- a/kubernetes/apps/hermes-sage/config/config.yaml
+++ b/kubernetes/apps/hermes-sage/config/config.yaml
@@ -7,6 +7,17 @@ model:
   default: qwen3.6-27b
   context_length: 64000
 
+# Registers vllm-aux as a second user-selectable model (dashboard model
+# picker / `/model` in chat) — distinct from auxiliary_models below, which
+# only routes specific internal tasks to it and doesn't make it selectable
+# on its own.
+providers:
+  vllm-aux:
+    base_url: http://vllm-aux.vllm.svc.cluster.local:8000/v1
+    models:
+      - qwen3.6-35b-a3b
+    context_length: 65536
+
 auxiliary_models:
   title:
     provider: custom


### PR DESCRIPTION
Answers "only seeing one local model" — `model:` (the shape both apps use) is a single-model shorthand that only ever registered `vllm-main`. `auxiliary_models:` routes specific internal tasks to `vllm-aux` but doesn't make it user-selectable.

Added a `providers:` entry for `vllm-aux` (found the exact schema in `hermes_cli/config.py`'s `_normalize_custom_provider_entry` — `base_url` + `models:` list is what registers a provider's models as selectable, distinct from the single-model `model:` shorthand). Both models should now show up separately in the dashboard's model picker / `/model` in chat.

Will verify live via `hermes config get providers` + a one-shot CLI call against `vllm-aux` after this merges, same as the dashboard PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the `vllm-aux` provider as an option in the dashboard model picker.
  * Added support for selecting `vllm-aux` through the `/model` chat command.
  * Configured the auxiliary provider with its endpoint, model, and context length.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->